### PR TITLE
Refactor version controllers to use MetadataVersionManager

### DIFF
--- a/docs/ai/controller_sharedlibraries_migration_matrix.md
+++ b/docs/ai/controller_sharedlibraries_migration_matrix.md
@@ -53,6 +53,9 @@ These rules are derived from [AI_CONTEXT.md](./AI_CONTEXT.md) and the current se
 - Round 1 also required a compatibility fix in legacy `Controllers/_usersController.cs` because it manually instantiated the refactored API controllers with the old constructor shape.
 - Round 2 implementation completed for the `Session` wave. The touched controllers now delegate to `SessionManager`, and direct session CouchDB/WebRequest logic was removed from the Round 2 target controllers.
 - Round 2 kept cookie/header access, route shapes, and `ViewBag`/`View()` composition in `mmria-server` while moving session list retrieval, `_session` orchestration, and password-expiration data lookup into `Session/Manager` and `Session/DAL`.
+- Round 3 implementation completed for the metadata/version wave using a new `MetadataVersion` feature in `mmria.common/SharedLibraries`.
+- Round 3 moved metadata document CRUD, attachment reads/writes, revision lookup, version save gating, UI specification CRUD, and validator/check-code attachment orchestration into `MetadataVersion/Manager` and `MetadataVersion/DAL`.
+- Round 3 intentionally left the `versionController` `export-names` action using the existing server-side utility because that path depends on server-only code and moving it would broaden the refactor beyond the “move as-is” goal.
 
 ## Spreadsheet-Style Matrix
 
@@ -86,13 +89,13 @@ Suggested status values:
 | 2 | `largely aligned` | `Controllers/api/sessionController.cs` | `Session` | Round 2 moved session list/search/filter and session document save orchestration into `Session` | session list/search/filter logic and session save orchestration | session sortable view and session document GET/PUT calls | route/actions and response shaping | Low | Completed in Round 2; controller no longer performs direct session CouchDB access |
 | 2 | `largely aligned` | `Controllers/api/sessionDBController.cs` | `Session` | Round 2 moved `_session` orchestration into `Session` | auth-session inspection and session DB orchestration | direct `_session` calls and cookie-aware request creation | request cookie/header handling and final action results | Medium | Completed in Round 2; preserved cookie pass-through semantics while moving the HTTP work into DAL |
 | 2 | `largely aligned` | `Controllers/HomeController.cs` | `Session` and `ManageUsers` | Round 2 replaced direct session-event and `_users` lookups with shared manager calls | password expiration calculation and power-BI user lookup orchestration | session event and `_users` queries | `ViewBag`, `View()`, route action | Medium | Completed in Round 2; page composition remains in controller and user lookup now reuses `ManageUsersManager` |
-| 3 | `planned` | `Controllers/api/metadataController.cs` | `MetadataVersion` | No SharedLibraries feature yet | metadata load/save orchestration, check-code load/save | metadata DB GET/PUT calls and revision fetch | request-body reads and final response formatting | Low | Strong candidate for as-is move |
-| 3 | `planned` | `Controllers/api/versionController.cs` | `MetadataVersion` | No SharedLibraries feature yet | version list/load/save, export-name-map orchestration | metadata/version doc and attachment reads/writes | `FileResult` creation and request-body plumbing | Medium | Large controller but mostly mechanical extraction |
-| 3 | `planned` | `Controllers/api/version_attachController.cs` | `MetadataVersion` | No SharedLibraries feature yet | version attachment save workflow | metadata attachment GET/PUT calls | body reading and final HTTP result | Low | Natural subfeature of metadata/version |
-| 3 | `planned` | `Controllers/api/version_code_genController.cs` | `MetadataVersion` | No SharedLibraries feature yet | version-code-gen orchestration | metadata/version fetches | route/action and final response | Low | Small and focused |
-| 3 | `planned` | `Controllers/api/ui_specificationController.cs` | `MetadataVersion` | No SharedLibraries feature yet | UI specification load/save orchestration | metadata attachment/doc reads and writes | route/action and final result | Low | Move with metadata/version wave |
-| 3 | `planned` | `Controllers/api/checkcodeController.cs` | `MetadataVersion` | No SharedLibraries feature yet | check-code load/save orchestration | metadata attachment/doc access | route/action and final result | Low | Move with metadata/version wave |
-| 3 | `planned` | `Controllers/api/validatorController.cs` | `MetadataVersion` | No SharedLibraries feature yet | validator asset orchestration | metadata attachment/doc access | route/action and final result | Low | Move with metadata/version wave |
+| 3 | `largely aligned` | `Controllers/api/metadataController.cs` | `MetadataVersion` | Round 3 extracted metadata doc and check-code orchestration into `MetadataVersion` | metadata load/save orchestration, version-spec save passthrough, check-code save orchestration | metadata doc GET/PUT and revision lookup | request-body reads and final response formatting | Low | Completed in Round 3; controller no longer performs direct CouchDB calls |
+| 3 | `largely aligned` | `Controllers/api/versionController.cs` | `MetadataVersion` | Round 3 extracted version list/load/save, validator fetch, and attachment save orchestration into `MetadataVersion` | version list/load/save, attachment save orchestration | metadata/version doc and attachment reads/writes | `FileResult` creation, request-body plumbing, and `export-names` server utility orchestration | Medium | Completed in Round 3; `export-names` intentionally remains controller-owned because the helper is server-only |
+| 3 | `largely aligned` | `Controllers/api/version_attachController.cs` | `MetadataVersion` | Round 3 moved version attachment save orchestration into `MetadataVersion` | version attachment save workflow and publish-state gating | metadata attachment GET/PUT calls and revision-dependent save path | body reading and manual form-body parsing | Low | Completed in Round 3; raw request parsing stays in controller for safety |
+| 3 | `largely aligned` | `Controllers/api/version_code_genController.cs` | `MetadataVersion` | Round 3 moved validator fetch to `MetadataVersion` but left schema code generation in controller | validator fetch orchestration only | validator attachment GET | route/action, final `ContentResult`, and `NJsonSchema` code generation | Low | Completed in Round 3 with codegen intentionally left in server because `NJsonSchema` is not referenced by `mmria.common` |
+| 3 | `largely aligned` | `Controllers/api/ui_specificationController.cs` | `MetadataVersion` | Round 3 extracted UI specification CRUD into `MetadataVersion` | UI specification load/save/delete orchestration | metadata doc reads/writes and delete calls | route/action and final result | Low | Completed in Round 3; controller is now a thin wrapper |
+| 3 | `largely aligned` | `Controllers/api/checkcodeController.cs` | `MetadataVersion` | Round 3 extracted check-code attachment get/put and revision handling into `MetadataVersion` | check-code load/save orchestration | metadata attachment/doc access and revision lookup | route/action and final result | Low | Completed in Round 3; namespace oddity left unchanged |
+| 3 | `largely aligned` | `Controllers/api/validatorController.cs` | `MetadataVersion` | Round 3 extracted validator attachment get/put and revision handling into `MetadataVersion` | validator asset orchestration | metadata attachment/doc access and revision lookup | route/action, request-body reads, and final `FileResult` | Low | Completed in Round 3; file response behavior preserved in controller |
 | 4 | `planned` | `Controllers/_auditController.cs` | `AuditRecovery` | No SharedLibraries feature yet | audit query orchestration, change-stack sorting/filtering, metadata-node lookup prep | audit `_find`, case lookup, metadata fetch | MVC view selection and view-model assembly | Medium | Keep Razor rendering in controller |
 | 4 | `planned` | `Controllers/api/AuditRecoverUtilController.cs` | `AuditRecovery` | No SharedLibraries feature yet | audit recovery workflows | audit and case view data access | route/action and final results | Medium | Pairs naturally with `_auditController` |
 | 4 | `planned` | `Controllers/api/caseRevisionController.cs` | `AuditRecovery` | No SharedLibraries feature yet | revision retrieval/recovery orchestration | revision fetches from case DB | route/actions and any actor-side follow-up | Medium | Current POST is mostly stubbed, but GET belongs here |
@@ -177,6 +180,23 @@ Round 2 implementation notes:
 - `sessionDBController` still owns request cookie access; only the actual `_session` HTTP work moved to `SessionDAL`
 - `HomeController` power-BI user lookup now reuses `ManageUsersManager.GetMyUserAsync(...)` instead of adding a new home-specific data access path
 - `SessionManager` preserves the existing password-expiration behavior by sorting session events the same way as the original controller logic
+
+## Round 3 Update
+
+Round 3 was implemented with the following outcomes:
+
+- Feature home added: `mmria.common/SharedLibraries/MetadataVersion`
+- Added `MetadataVersionDAL` to own metadata document reads/writes, attachment reads/writes, deletes, and revision lookup
+- Added `MetadataVersionManager` to own metadata/version/UI-specification orchestration, validator/check-code save orchestration, and version publish-state gating
+- Registered `MetadataVersionDAL` and `MetadataVersionManager` in server DI
+- Preserved routes, action signatures, and response shapes for all seven Round 3 target controllers
+- Verified by build: `dotnet build source-code/mmria/mmria-server/mmria-server.csproj`
+
+Round 3 implementation notes:
+
+- `versionController` still owns the `export-names` action because it depends on the existing server-only `export_all_generate_name_map` helper
+- `version_attachController` still owns manual request-body parsing to avoid changing fragile form-body behavior
+- `version_code_genController` still owns `NJsonSchema` code generation because `mmria.common` does not reference that package and adding it would be a broader dependency change
 
 ## First-Pass Refactoring Pattern
 

--- a/nccdphp-drh-mmria-common/mmria.common/SharedLibraries/AuditRecovery/DAL/AuditRecoveryDAL.cs
+++ b/nccdphp-drh-mmria-common/mmria.common/SharedLibraries/AuditRecovery/DAL/AuditRecoveryDAL.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Threading.Tasks;
+using mmria.common.couchdb;
+using mmria.common.metadata;
+using mmria.common.model.couchdb;
+using mmria.common.model.couchdb.audit;
+using mmria.common.SharedLibraries.AuditRecovery.Model;
+using Newtonsoft.Json;
+
+namespace mmria.common.SharedLibraries.AuditRecovery.DAL;
+
+public sealed class AuditRecoveryDAL
+{
+    private readonly mmria.common.getset.CouchDbHttpClient _couchDbHttpClient;
+
+    public AuditRecoveryDAL(mmria.common.getset.CouchDbHttpClient couchDbHttpClient)
+    {
+        _couchDbHttpClient = couchDbHttpClient;
+    }
+
+    public async Task<case_view_response> GetCaseViewResponseAsync(string caseId, DBConfigurationDetail db_config)
+    {
+        string request = $"{db_config.url}/{db_config.prefix}mmrds/_design/sortable/_view/by_id?key=\"{caseId}\"";
+        string response = await _couchDbHttpClient.ExecuteAsync("GET", request, null, db_config.user_name, db_config.user_value);
+        return JsonConvert.DeserializeObject<case_view_response>(response);
+    }
+
+    public async Task<ChangeStackResult> FindChangeStacksAsync(string requestUrl, string postData, DBConfigurationDetail db_config)
+    {
+        string response = await _couchDbHttpClient.ExecuteAsync("POST", requestUrl, postData, db_config.user_name, db_config.user_value);
+        return JsonConvert.DeserializeObject<ChangeStackResult>(response);
+    }
+
+    public async Task<Change_Stack> GetChangeStackAsync(string changeId, DBConfigurationDetail db_config)
+    {
+        string request = $"{db_config.url}/{db_config.prefix}audit/{changeId}";
+        string response = await _couchDbHttpClient.ExecuteAsync("GET", request, null, db_config.user_name, db_config.user_value);
+        return JsonConvert.DeserializeObject<Change_Stack>(response);
+    }
+
+    public async Task<app> GetMetadataAsync(string metadataVersion, DBConfigurationDetail db_config)
+    {
+        string request = $"{db_config.url}/metadata/version_specification-{metadataVersion}/metadata";
+        string response = await _couchDbHttpClient.ExecuteAsync("GET", request, null, null, null);
+        return JsonConvert.DeserializeObject<app>(response);
+    }
+
+    public async Task<Audit_Manage_User> GetAuditManageUserAsync(DBConfigurationDetail db_config)
+    {
+        string request = $"{db_config.url}/{db_config.prefix}audit/audit-manage-user";
+        string response = await _couchDbHttpClient.ExecuteAsync("GET", request, null, db_config.user_name, db_config.user_value);
+        if (response.Contains("\"error\":\"not_found\""))
+        {
+            return null;
+        }
+
+        return JsonConvert.DeserializeObject<Audit_Manage_User>(response);
+    }
+
+    public async Task<document_put_response> SaveAuditManageUserAsync(Audit_Manage_User auditDocument, DBConfigurationDetail db_config)
+    {
+        string body = JsonConvert.SerializeObject(auditDocument, new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore
+        });
+
+        string request = $"{db_config.url}/{db_config.prefix}audit/{auditDocument._id}";
+        string response = await _couchDbHttpClient.ExecuteAsync("PUT", request, body, db_config.user_name, db_config.user_value);
+        return JsonConvert.DeserializeObject<document_put_response>(response);
+    }
+
+    public async Task<ExpandoObject> GetCaseRevisionAsync(string caseId, string revisionId, DBConfigurationDetail db_config)
+    {
+        string request = $"{db_config.url}/{db_config.prefix}mmrds/{caseId}?rev={revisionId}";
+        string response = await _couchDbHttpClient.ExecuteAsync("GET", request, null, db_config.user_name, db_config.user_value);
+        return JsonConvert.DeserializeObject<ExpandoObject>(response);
+    }
+}

--- a/nccdphp-drh-mmria-common/mmria.common/SharedLibraries/AuditRecovery/Manager/AuditRecoveryManager.cs
+++ b/nccdphp-drh-mmria-common/mmria.common/SharedLibraries/AuditRecovery/Manager/AuditRecoveryManager.cs
@@ -1,0 +1,338 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using mmria.common.couchdb;
+using mmria.common.metadata;
+using mmria.common.model.couchdb;
+using mmria.common.model.couchdb.audit;
+using mmria.common.SharedLibraries.AuditRecovery.DAL;
+using mmria.common.SharedLibraries.AuditRecovery.Model;
+using Newtonsoft.Json;
+
+namespace mmria.common.SharedLibraries.AuditRecovery.Manager;
+
+public sealed class AuditRecoveryManager
+{
+    private readonly AuditRecoveryDAL _dal;
+
+    public AuditRecoveryManager(AuditRecoveryDAL dal)
+    {
+        _dal = dal;
+    }
+
+    public async Task<AuditRecoveryViewData> GetAuditViewDataAsync(
+        string caseId,
+        int page,
+        string user,
+        string search_text,
+        bool showAll,
+        DBConfigurationDetail db_config,
+        CancellationToken cancellationToken)
+    {
+        var case_view_response = await _dal.GetCaseViewResponseAsync(caseId, db_config);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        case_view_sortable_item case_view_item = case_view_response.rows.Where(i => i.id == caseId).FirstOrDefault().value;
+        var (request_string, post_data) = GetFindUrl(db_config, caseId);
+        var view_response = await _dal.FindChangeStacksAsync(request_string, post_data, db_config);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        List<Change_Stack> result = new();
+        foreach (var item in view_response.docs)
+        {
+            for (var i = 0; i < item.items.Count; i++)
+            {
+                item.items[i].temp_index = i;
+            }
+
+            item.items.Sort(new ChangeStackItemDescendingDate());
+
+            if (showAll)
+            {
+                result.Add(DebounceDateTimeField(item));
+            }
+            else if (item.items.Count > 0 && item.case_id == caseId)
+            {
+                result.Add(DebounceDateTimeField(item));
+            }
+        }
+
+        const int page_size = 50;
+        result.Sort(new ChangeStackDescendingDate());
+
+        return new AuditRecoveryViewData
+        {
+            id = caseId,
+            user = user,
+            search_text = search_text,
+            showAll = showAll,
+            cv = case_view_item,
+            ls = page == -1 ? result : result.Skip((page - 1) * page_size).Take(page_size).ToList(),
+            page_size = page_size,
+            page = page,
+            total = result.Count
+        };
+    }
+
+    public async Task<AuditRecoveryDetailData> GetAuditDetailDataAsync(
+        string caseId,
+        string changeId,
+        int changeItem,
+        DBConfigurationDetail db_config,
+        CancellationToken cancellationToken)
+    {
+        var case_view_response = await _dal.GetCaseViewResponseAsync(caseId, db_config);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        case_view_sortable_item case_view_item = case_view_response.rows.Where(i => i.id == caseId).FirstOrDefault().value;
+        var cs = await _dal.GetChangeStackAsync(changeId, db_config);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        for (var i = 0; i < cs.items.Count; i++)
+        {
+            cs.items[i].temp_index = i;
+        }
+
+        var metadata = await _dal.GetMetadataAsync(cs.metadata_version, db_config);
+        var lookup = GetLookUp(metadata);
+        var node = GetMetadataNode(metadata, cs.items[changeItem].dictionary_path.Trim().TrimStart('/'));
+
+        if (node == null)
+        {
+            return new AuditRecoveryDetailData
+            {
+                id = caseId,
+                change_id = changeId,
+                cv = case_view_item,
+                cs = cs,
+                change_item = changeItem,
+                MetadataNode = metadata.AsNode()
+            };
+        }
+
+        var converted = ConvertNode(node, lookup);
+        return new AuditRecoveryDetailData
+        {
+            id = caseId,
+            change_id = changeId,
+            cv = case_view_item,
+            cs = cs,
+            change_item = changeItem,
+            MetadataNode = node,
+            value_to_display = converted.value_to_display,
+            display_to_value = converted.display_to_value
+        };
+    }
+
+    public async Task<Audit_Manage_User> GetAuditDocumentAsync(DBConfigurationDetail db_config)
+    {
+        return await _dal.GetAuditManageUserAsync(db_config);
+    }
+
+    public async Task<document_put_response> SaveAuditDocumentAsync(Audit_Manage_User auditDocument, DBConfigurationDetail db_config)
+    {
+        return await _dal.SaveAuditManageUserAsync(auditDocument, db_config);
+    }
+
+    public async Task<System.Dynamic.ExpandoObject> GetCaseRevisionAsync(string caseId, string revisionId, DBConfigurationDetail db_config)
+    {
+        return await _dal.GetCaseRevisionAsync(caseId, revisionId, db_config);
+    }
+
+    private static (string url, string post) GetFindUrl(DBConfigurationDetail db_config, string caseId)
+    {
+        var selector_struc = new AuditSelector();
+        selector_struc.selector = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+        selector_struc.limit = 1_000_000;
+        selector_struc.selector.Add("case_id", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+        selector_struc.selector["case_id"].Add("$eq", caseId);
+        selector_struc.use_index = "case-id-date-last-updated-index";
+
+        string selector_struc_string = JsonConvert.SerializeObject(selector_struc, new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore
+        });
+
+        string result = $"{db_config.url}/{db_config.prefix}audit/_find";
+        return (result, selector_struc_string);
+    }
+
+    private static Dictionary<string, value_node[]> GetLookUp(app metadata)
+    {
+        var result = new Dictionary<string, value_node[]>(StringComparer.OrdinalIgnoreCase);
+        foreach (var node in metadata.lookup)
+        {
+            result.Add("lookup/" + node.name, node.values);
+        }
+
+        return result;
+    }
+
+    private static node GetMetadataNode(app metadata, string path)
+    {
+        node result = null;
+        node current = null;
+        string[] splitPath = path.Split("/");
+
+        for (int i = 0; i < splitPath.Length; i++)
+        {
+            string current_name = splitPath[i];
+            if (i == 0)
+            {
+                foreach (var child in metadata.children)
+                {
+                    if (child.name.Equals(current_name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        current = child;
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                if (current.children != null)
+                {
+                    foreach (var child2 in current.children)
+                    {
+                        if (child2.name.Equals(current_name, StringComparison.OrdinalIgnoreCase))
+                        {
+                            current = child2;
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    return result;
+                }
+
+                if (i == splitPath.Length - 1)
+                {
+                    result = current;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static (Dictionary<string, string> display_to_value, Dictionary<string, string> value_to_display) ConvertNode(node value, Dictionary<string, value_node[]> lookup)
+    {
+        Dictionary<string, string> display_to_value = new(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, string> value_to_display = new(StringComparer.OrdinalIgnoreCase);
+
+        if (!string.IsNullOrWhiteSpace(value.path_reference))
+        {
+            var key = value.path_reference;
+            if (lookup.ContainsKey(key))
+            {
+                value.values = lookup[key];
+            }
+        }
+
+        if (value.values != null)
+        {
+            foreach (var value_item in value.values)
+            {
+                var v = value_item.value;
+                var display = value_item.display;
+
+                if (!value_to_display.ContainsKey(v))
+                {
+                    value_to_display.Add(v, display);
+                }
+
+                if (!display_to_value.ContainsKey(display))
+                {
+                    display_to_value.Add(display, v);
+                }
+            }
+        }
+
+        return (display_to_value, value_to_display);
+    }
+
+    private static Change_Stack DebounceDateTimeField(Change_Stack value)
+    {
+        var result = new Change_Stack()
+        {
+            _id = value._id,
+            _rev = value._rev,
+            case_id = value.case_id,
+            case_rev = value.case_rev,
+            user_name = value.user_name,
+            note = value.note,
+            metadata_version = value.metadata_version,
+            date_created = value.date_created
+        };
+
+        string found_path = "";
+        int found_index = -1;
+        int last_index = -1;
+        int target_index = -1;
+        for (var subitem_index = 0; subitem_index < value.items.Count; subitem_index++)
+        {
+            var subitem = value.items[subitem_index];
+
+            if (subitem.metadata_type.ToUpper() == "DATETIME")
+            {
+                if (subitem.dictionary_path == found_path)
+                {
+                    last_index = subitem_index;
+                    continue;
+                }
+                else
+                {
+                    found_path = subitem.dictionary_path;
+                    found_index = subitem_index;
+                    target_index = result.items.Count;
+                    result.items.Add(subitem);
+                }
+            }
+            else
+            {
+                if (!string.IsNullOrWhiteSpace(found_path))
+                {
+                    if (last_index > -1)
+                    {
+                        result.items[target_index].old_value = value.items[last_index].old_value;
+                    }
+
+                    result.items[target_index].new_value = value.items[found_index].new_value;
+                    found_path = "";
+                    found_index = -1;
+                    last_index = -1;
+                    target_index = -1;
+                }
+
+                result.items.Add(subitem);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(found_path) && last_index > -1)
+        {
+            result.items[target_index].old_value = value.items[last_index].old_value;
+            result.items[target_index].new_value = value.items[found_index].new_value;
+        }
+
+        return result;
+    }
+
+    public sealed class ChangeStackDescendingDate : IComparer<Change_Stack>
+    {
+        public int Compare(Change_Stack x, Change_Stack y)
+        {
+            return y.date_created.Value.CompareTo(x.date_created.Value);
+        }
+    }
+
+    public sealed class ChangeStackItemDescendingDate : IComparer<Change_Stack_Item>
+    {
+        public int Compare(Change_Stack_Item x, Change_Stack_Item y)
+        {
+            return y.date_created.Value.CompareTo(x.date_created.Value);
+        }
+    }
+}

--- a/nccdphp-drh-mmria-common/mmria.common/SharedLibraries/AuditRecovery/Model/AuditRecoveryModels.cs
+++ b/nccdphp-drh-mmria-common/mmria.common/SharedLibraries/AuditRecovery/Model/AuditRecoveryModels.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using mmria.common.metadata;
+using mmria.common.model.couchdb;
+
+namespace mmria.common.SharedLibraries.AuditRecovery.Model;
+
+public sealed class AuditRecoveryViewData
+{
+    public string id { get; set; }
+    public string user { get; set; } = "all";
+    public string search_text { get; set; } = "all";
+    public bool showAll { get; set; }
+    public case_view_sortable_item cv { get; set; }
+    public List<Change_Stack> ls { get; set; } = new();
+    public int page_size { get; set; }
+    public int page { get; set; }
+    public int total { get; set; }
+}
+
+public sealed class AuditRecoveryDetailData
+{
+    public string id { get; set; }
+    public string change_id { get; set; }
+    public int change_item { get; set; }
+    public bool showAll { get; set; }
+    public case_view_sortable_item cv { get; set; }
+    public Change_Stack cs { get; set; }
+    public node MetadataNode { get; set; }
+    public Dictionary<string, string> value_to_display { get; set; }
+    public Dictionary<string, string> display_to_value { get; set; }
+}
+
+public struct ChangeStackResult
+{
+    public Change_Stack[] docs;
+}
+
+public struct AuditSelector
+{
+    public Dictionary<string, Dictionary<string, string>> selector;
+    public string[] fields;
+    public string use_index;
+    public int limit;
+}

--- a/nccdphp-drh-mmria-common/mmria.common/SharedLibraries/MetadataVersion/DAL/MetadataVersionDAL.cs
+++ b/nccdphp-drh-mmria-common/mmria.common/SharedLibraries/MetadataVersion/DAL/MetadataVersionDAL.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Threading.Tasks;
+using mmria.common.couchdb;
+using mmria.common.model.couchdb;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace mmria.common.SharedLibraries.MetadataVersion.DAL;
+
+public sealed class MetadataVersionDAL
+{
+    private readonly mmria.common.getset.CouchDbHttpClient _couchDbHttpClient;
+
+    public MetadataVersionDAL(mmria.common.getset.CouchDbHttpClient couchDbHttpClient)
+    {
+        _couchDbHttpClient = couchDbHttpClient;
+    }
+
+    public async Task<ExpandoObject> GetExpandoDocumentAsync(
+        string requestUrl,
+        string userName,
+        string userValue)
+    {
+        string response = await _couchDbHttpClient.ExecuteAsync("GET", requestUrl, null, userName, userValue);
+        return JsonConvert.DeserializeObject<ExpandoObject>(response, new ExpandoObjectConverter());
+    }
+
+    public async Task<string> GetStringAsync(
+        string requestUrl,
+        string userName,
+        string userValue)
+    {
+        return await _couchDbHttpClient.ExecuteAsync("GET", requestUrl, null, userName, userValue);
+    }
+
+    public async Task<T> GetDocumentAsync<T>(
+        string requestUrl,
+        string userName,
+        string userValue,
+        JsonSerializerSettings settings = null)
+    {
+        string response = await _couchDbHttpClient.ExecuteAsync("GET", requestUrl, null, userName, userValue);
+        return settings == null
+            ? JsonConvert.DeserializeObject<T>(response)
+            : JsonConvert.DeserializeObject<T>(response, settings);
+    }
+
+    public async Task<get_response_header<T>> GetAllDocsAsync<T>(
+        string requestUrl,
+        string userName,
+        string userValue,
+        JsonSerializerSettings settings)
+    {
+        string response = await _couchDbHttpClient.ExecuteAsync("GET", requestUrl, null, userName, userValue);
+        return JsonConvert.DeserializeObject<get_response_header<T>>(response, settings);
+    }
+
+    public async Task<document_put_response> PutJsonAsync(
+        string requestUrl,
+        string json,
+        string userName,
+        string userValue)
+    {
+        string response = await _couchDbHttpClient.ExecuteAsync("PUT", requestUrl, json, userName, userValue);
+        return JsonConvert.DeserializeObject<document_put_response>(response);
+    }
+
+    public async Task<document_put_response> PutTextAsync(
+        string requestUrl,
+        string content,
+        string userName,
+        string userValue,
+        Dictionary<string, string> headers = null)
+    {
+        string response = await _couchDbHttpClient.ExecuteAsync("PUT", requestUrl, content, userName, userValue, "text/*", headers);
+        return JsonConvert.DeserializeObject<document_put_response>(response);
+    }
+
+    public async Task<ExpandoObject> DeleteDocumentAsync(
+        string requestUrl,
+        string userName,
+        string userValue)
+    {
+        string response = await _couchDbHttpClient.ExecuteAsync("DELETE", requestUrl, null, userName, userValue);
+        return JsonConvert.DeserializeObject<ExpandoObject>(response, new ExpandoObjectConverter());
+    }
+
+    public async Task<string> GetRevisionAsync(
+        string requestUrl,
+        string userName,
+        string userValue)
+    {
+        string response = await _couchDbHttpClient.ExecuteAsync("GET", requestUrl, null, userName, userValue);
+        var result = JsonConvert.DeserializeObject<ExpandoObject>(response, new ExpandoObjectConverter());
+        IDictionary<string, object> updater = result as IDictionary<string, object>;
+        if (updater != null && updater.ContainsKey("_rev"))
+        {
+            return updater["_rev"]?.ToString();
+        }
+
+        return null;
+    }
+}

--- a/nccdphp-drh-mmria-common/mmria.common/SharedLibraries/MetadataVersion/Manager/MetadataVersionManager.cs
+++ b/nccdphp-drh-mmria-common/mmria.common/SharedLibraries/MetadataVersion/Manager/MetadataVersionManager.cs
@@ -1,0 +1,389 @@
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Threading.Tasks;
+using mmria.common.couchdb;
+using mmria.common.metadata;
+using mmria.common.model.couchdb;
+using mmria.common.SharedLibraries.MetadataVersion.DAL;
+using Newtonsoft.Json;
+
+namespace mmria.common.SharedLibraries.MetadataVersion.Manager;
+
+public sealed class MetadataVersionManager
+{
+    private const string DefaultMetadataId = "2016-06-12T13:49:24.759Z";
+    private const string DeIdentifiedListId = "de-identified-list";
+    private const string DefaultUiSpecificationId = "default-ui-specification";
+    private const string DefaultVersionSpecificationId = "default_version_specification";
+    private const string CheckCodeAttachmentName = "mmria-check-code.js";
+    private const string ValidatorAttachmentName = "validator.js";
+
+    private readonly MetadataVersionDAL _dal;
+
+    public MetadataVersionManager(MetadataVersionDAL dal)
+    {
+        _dal = dal;
+    }
+
+    public async Task<ExpandoObject> GetMetadataAsync(DBConfigurationDetail db_config)
+    {
+        return await _dal.GetExpandoDocumentAsync(
+            $"{db_config.url}/metadata/{DefaultMetadataId}",
+            null,
+            null);
+    }
+
+    public async Task<ExpandoObject> GetMetadataAsync(string id, DBConfigurationDetail db_config)
+    {
+        return await _dal.GetExpandoDocumentAsync(
+            $"{db_config.url}/metadata/{id}",
+            null,
+            null);
+    }
+
+    public async Task<document_put_response> SaveMetadataAsync(app metadata, DBConfigurationDetail db_config)
+    {
+        string object_string = JsonConvert.SerializeObject(metadata, CreateSerializerSettings());
+        return await _dal.PutJsonAsync($"{db_config.url}/metadata/{metadata._id}", object_string, db_config.user_name, db_config.user_value);
+    }
+
+    public async Task<string> GetCheckCodeAsync(DBConfigurationDetail db_config)
+    {
+        return await _dal.GetStringAsync(
+            $"{db_config.url}/metadata/{DefaultMetadataId}/{CheckCodeAttachmentName}",
+            null,
+            null);
+    }
+
+    public async Task<document_put_response> SaveCheckCodeAsync(string check_code_json, DBConfigurationDetail db_config)
+    {
+        string revision = null;
+        try
+        {
+            revision = await _dal.GetRevisionAsync($"{db_config.url}/metadata/{DefaultMetadataId}", db_config.user_name, db_config.user_value);
+        }
+        catch (Exception ex)
+        {
+            if (!(ex.Message.IndexOf("(404) Object Not Found") > -1))
+            {
+                throw;
+            }
+        }
+
+        Dictionary<string, string> headers = null;
+        if (!string.IsNullOrWhiteSpace(revision))
+        {
+            headers = new Dictionary<string, string> { { "If-Match", revision } };
+        }
+
+        return await _dal.PutTextAsync(
+            $"{db_config.url}/metadata/{DefaultMetadataId}/{CheckCodeAttachmentName}",
+            check_code_json,
+            db_config.user_name,
+            db_config.user_value,
+            headers);
+    }
+
+    public async Task<document_put_response> SaveMetadataVersionSpecificationAsync(Version_Specification versionSpecification, DBConfigurationDetail db_config)
+    {
+        if (!IsValidMetadataVersionSpecification(versionSpecification))
+        {
+            return null;
+        }
+
+        string json_string = JsonConvert.SerializeObject(versionSpecification, CreateSerializerSettings());
+        return await _dal.PutJsonAsync($"{db_config.url}/metadata/{versionSpecification._id}", json_string, db_config.user_name, db_config.user_value);
+    }
+
+    public async Task<List<Version_Specification>> ListVersionSpecificationsAsync(DBConfigurationDetail db_config)
+    {
+        var response = await _dal.GetAllDocsAsync<Version_Specification>(
+            $"{db_config.url}/metadata/_all_docs?include_docs=true",
+            db_config.user_name,
+            db_config.user_value,
+            CreateSerializerSettings());
+
+        var result = new List<Version_Specification>();
+        foreach (var row in response.rows)
+        {
+            var version_specification = row.doc;
+            if
+            (
+                version_specification.data_type == null ||
+                version_specification.data_type != "version-specification" ||
+                version_specification._id == DefaultMetadataId ||
+                version_specification._id == DeIdentifiedListId
+            )
+            {
+                continue;
+            }
+
+            result.Add(row.doc);
+        }
+
+        return result;
+    }
+
+    public async Task<Version_Specification> GetVersionSpecificationMetadataAsync(string version_specification_id, DBConfigurationDetail db_config)
+    {
+        return await _dal.GetDocumentAsync<Version_Specification>(
+            $"{db_config.url}/metadata/version_specification-{version_specification_id}",
+            db_config.user_name,
+            db_config.user_value);
+    }
+
+    public async Task<string> GetValidatorAsync(DBConfigurationDetail db_config)
+    {
+        return await _dal.GetStringAsync(
+            $"{db_config.url}/metadata/{DefaultMetadataId}/{ValidatorAttachmentName}",
+            null,
+            null);
+    }
+
+    public async Task<string> GetVersionDocumentAsync(string version_specification_id, string document_name, DBConfigurationDetail db_config)
+    {
+        return await _dal.GetStringAsync(
+            $"{db_config.url}/metadata/version_specification-{version_specification_id}/{document_name}",
+            null,
+            null);
+    }
+
+    public async Task<document_put_response> SaveVersionSpecificationAsync(Version_Specification versionSpecification, DBConfigurationDetail db_config)
+    {
+        string id_val = versionSpecification._id;
+        bool save_document = false;
+
+        if (!string.IsNullOrWhiteSpace(versionSpecification._rev))
+        {
+            try
+            {
+                var check_result = await _dal.GetDocumentAsync<Version_Specification>(
+                    $"{db_config.url}/metadata/{id_val}",
+                    db_config.user_name,
+                    db_config.user_value);
+
+                if
+                (
+                    !string.IsNullOrWhiteSpace(check_result.data_type) &&
+                    check_result.data_type == "version-specification"
+                )
+                {
+                    if (string.IsNullOrWhiteSpace(check_result.data_type))
+                    {
+                        save_document = true;
+                    }
+                    else if (check_result.publish_status != publish_status_enum.final)
+                    {
+                        save_document = true;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+        }
+
+        if (!save_document)
+        {
+            return new document_put_response();
+        }
+
+        string object_string = JsonConvert.SerializeObject(versionSpecification, new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore
+        });
+
+        return await _dal.PutJsonAsync($"{db_config.url}/metadata/{id_val}", object_string, db_config.user_name, db_config.user_value);
+    }
+
+    public async Task<document_put_response> SaveVersionAttachmentAsync(Add_Attachement add_attachement, DBConfigurationDetail db_config, bool requireEditableVersion)
+    {
+        if (add_attachement == null || IsAlwaysProtectedVersionAttachmentId(add_attachement._id))
+        {
+            return null;
+        }
+
+        if (requireEditableVersion)
+        {
+            if (add_attachement._id == "default_ui_specification")
+            {
+                return null;
+            }
+
+            bool save_document = false;
+
+            try
+            {
+                var check_result = await _dal.GetDocumentAsync<Version_Specification>(
+                    $"{db_config.url}/metadata/{add_attachement._id}",
+                    db_config.user_name,
+                    db_config.user_value);
+
+                if
+                (
+                    !string.IsNullOrWhiteSpace(check_result.data_type) &&
+                    check_result.data_type == "version-specification"
+                )
+                {
+                    if (string.IsNullOrWhiteSpace(check_result.data_type))
+                    {
+                        save_document = true;
+                    }
+                    else if (check_result.publish_status != publish_status_enum.final)
+                    {
+                        save_document = true;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+
+            if (!save_document)
+            {
+                return new document_put_response();
+            }
+        }
+
+        var headerDict = new Dictionary<string, string>();
+        headerDict.Add("If-Match", add_attachement._rev);
+
+        return await _dal.PutTextAsync(
+            $"{db_config.url}/metadata/{add_attachement._id}/{add_attachement.doc_name}",
+            add_attachement.document_content,
+            db_config.user_name,
+            db_config.user_value,
+            headerDict);
+    }
+
+    public async Task<List<UI_Specification>> ListUiSpecificationsAsync(DBConfigurationDetail db_config)
+    {
+        var response = await _dal.GetAllDocsAsync<UI_Specification>(
+            $"{db_config.url}/metadata/_all_docs?include_docs=true",
+            db_config.user_name,
+            db_config.user_value,
+            CreateSerializerSettings());
+
+        var result = new List<UI_Specification>();
+        foreach (var row in response.rows)
+        {
+            var ui_specification = row.doc;
+            if
+            (
+                ui_specification.data_type == null ||
+                ui_specification.data_type != "ui-specification" ||
+                ui_specification._id == DefaultMetadataId ||
+                ui_specification._id == DeIdentifiedListId
+            )
+            {
+                continue;
+            }
+
+            result.Add(row.doc);
+        }
+
+        return result;
+    }
+
+    public async Task<UI_Specification> GetUiSpecificationAsync(string id, DBConfigurationDetail db_config)
+    {
+        return await _dal.GetDocumentAsync<UI_Specification>(
+            $"{db_config.url}/metadata/{id}",
+            db_config.user_name,
+            db_config.user_value,
+            CreateSerializerSettings());
+    }
+
+    public async Task<document_put_response> SaveUiSpecificationAsync(UI_Specification ui_specification, DBConfigurationDetail db_config)
+    {
+        if (!IsValidUiSpecification(ui_specification))
+        {
+            return null;
+        }
+
+        string ui_specification_json = JsonConvert.SerializeObject(ui_specification, CreateSerializerSettings());
+        return await _dal.PutJsonAsync($"{db_config.url}/metadata/{ui_specification._id}", ui_specification_json, db_config.user_name, db_config.user_value);
+    }
+
+    public async Task<ExpandoObject> DeleteUiSpecificationAsync(string id, string rev, DBConfigurationDetail db_config)
+    {
+        if
+        (
+            string.IsNullOrWhiteSpace(id) ||
+            string.IsNullOrWhiteSpace(rev) ||
+            id == DefaultUiSpecificationId ||
+            id == DefaultMetadataId ||
+            id == DeIdentifiedListId
+        )
+        {
+            return null;
+        }
+
+        return await _dal.DeleteDocumentAsync($"{db_config.url}/metadata/{id}?rev={rev}", db_config.user_name, db_config.user_value);
+    }
+
+    public async Task<document_put_response> SaveValidatorAsync(string validator_js_text, DBConfigurationDetail db_config)
+    {
+        string revision = null;
+        try
+        {
+            revision = await _dal.GetRevisionAsync($"{db_config.url}/metadata/{DefaultMetadataId}", db_config.user_name, db_config.user_value);
+        }
+        catch (Exception ex)
+        {
+            if (!(ex.Message.IndexOf("(404) Object Not Found") > -1))
+            {
+                throw;
+            }
+        }
+
+        var headerDict = new Dictionary<string, string>();
+        if (!string.IsNullOrWhiteSpace(revision))
+        {
+            headerDict.Add("If-Match", revision);
+        }
+
+        return await _dal.PutTextAsync(
+            $"{db_config.url}/metadata/{DefaultMetadataId}/{ValidatorAttachmentName}",
+            validator_js_text,
+            db_config.user_name,
+            db_config.user_value,
+            headerDict);
+    }
+
+    private static JsonSerializerSettings CreateSerializerSettings()
+    {
+        return new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+            MissingMemberHandling = MissingMemberHandling.Ignore
+        };
+    }
+
+    private static bool IsValidMetadataVersionSpecification(Version_Specification versionSpecification)
+    {
+        return versionSpecification.data_type != null &&
+            versionSpecification.data_type == "version-specification" &&
+            versionSpecification._id != DefaultMetadataId &&
+            versionSpecification._id != DeIdentifiedListId;
+    }
+
+    private static bool IsValidUiSpecification(UI_Specification ui_specification)
+    {
+        return ui_specification.data_type != null &&
+            ui_specification.data_type == "ui-specification" &&
+            ui_specification._id != DefaultMetadataId &&
+            ui_specification._id != DeIdentifiedListId;
+    }
+
+    private static bool IsAlwaysProtectedVersionAttachmentId(string id)
+    {
+        return id == DefaultVersionSpecificationId ||
+            id == DefaultMetadataId ||
+            id == DeIdentifiedListId;
+    }
+}

--- a/source-code/mmria/mmria-server/Controllers/_auditController.cs
+++ b/source-code/mmria/mmria-server/Controllers/_auditController.cs
@@ -70,7 +70,7 @@ public sealed class _auditController : Controller
     List<mmria.common.couchdb.OverridableConfiguration> _overridableConfigSets;
     List<mmria.common.couchdb.ConfigurationSet> _dbConfigSets;
     common.couchdb.DBConfigurationDetail db_config;
-    private readonly mmria.common.getset.CouchDbHttpClient _couchDbHttpClient;
+    private readonly mmria.common.SharedLibraries.AuditRecovery.Manager.AuditRecoveryManager _auditRecoveryManager;
     string host_prefix = null;
     private Dictionary<string, mmria.common.metadata.value_node[]> lookup;
     public _auditController
@@ -79,12 +79,12 @@ public sealed class _auditController : Controller
         mmria.common.couchdb.OverridableConfiguration _configuration,
         List<mmria.common.couchdb.OverridableConfiguration> overridableConfigSets,
         List<mmria.common.couchdb.ConfigurationSet> dbConfigSets,
-        mmria.common.getset.CouchDbHttpClient couchDbHttpClient
+        mmria.common.SharedLibraries.AuditRecovery.Manager.AuditRecoveryManager auditRecoveryManager
     )
     {
         _overridableConfigSets = overridableConfigSets;
         _dbConfigSets = dbConfigSets;
-        _couchDbHttpClient = couchDbHttpClient;
+        _auditRecoveryManager = auditRecoveryManager;
         host_prefix = httpContextAccessor.HttpContext.Request.Host.GetPrefix();
         configuration = mmria.server.util.MultiTenantConfigHelper.GetConfigurationForTenant(_overridableConfigSets, _configuration, host_prefix);
         db_config = mmria.server.util.MultiTenantConfigHelper.GetDBConfigForTenant(_dbConfigSets, _configuration, host_prefix);
@@ -110,175 +110,53 @@ public sealed class _auditController : Controller
     [Route("_audit/{p_id}/{page?}")]
     public async Task<IActionResult> Index(System.Threading.CancellationToken cancellationToken, string p_id, int page = -1, string user = "all", string search_text = "all", bool showAll = false)
     {
-
-        var case_view_request_string = $"{db_config.url}/{db_config.prefix}mmrds/_design/sortable/_view/by_id?key=\"{p_id}\"";
-
-        string responseFromServer = await _couchDbHttpClient.ExecuteAsync(
-            "GET",
-            case_view_request_string,
-            null,
-            db_config.user_name,
-            db_config.user_value
-        );
-
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var case_view_response = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.case_view_response>(responseFromServer);
-
-
-        mmria.common.model.couchdb.case_view_sortable_item case_view_item =
-            case_view_response.rows.Where(i => i.id == p_id).FirstOrDefault().value;
-
-
-        //var request_string = $"{configuration["mmria_settings:couchdb_url}/{configuration["mmria_settings:db_prefix}audit/_all_docs?include_docs=true";
-        var (request_string, post_data) = get_find_url(p_id);
-        responseFromServer = await _couchDbHttpClient.ExecuteAsync(
-            "POST",
-            request_string,
-            post_data,
-            db_config.user_name,
-            db_config.user_value
-        );
-
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var view_response = Newtonsoft.Json.JsonConvert.DeserializeObject<Change_Stack_Result_Struct>(responseFromServer);
-
-        List<mmria.common.model.couchdb.Change_Stack> result = new();
-
-        foreach (var item in view_response.docs)
-        {
-
-            for (var i = 0; i < item.items.Count; i++)
-            {
-                item.items[i].temp_index = i;
-            }
-
-            for (var subitem_index = 0; subitem_index < item.items.Count; subitem_index++)
-            {
-                var subitem = item.items[subitem_index];
-
-
-
-            }
-
-            item.items.Sort(new Change_Stack_Item_DescendingDate());
-
-            if (showAll)
-            {
-                result.Add(DebounceDateTimeField(item));
-            }
-            else if (item.items.Count > 0 && item.case_id == p_id)
-            {
-
-                result.Add(DebounceDateTimeField(item));
-            }
-        }
-
-        const int page_size = 50;
-
-        result.Sort(new Change_Stack_DescendingDate());
+        var data = await _auditRecoveryManager.GetAuditViewDataAsync(p_id, page, user, search_text, showAll, db_config, cancellationToken);
         return View
         (
             new Audit_View()
             {
-                id = p_id,
-                user = user,
-                search_text = search_text,
-                showAll = showAll,
-                cv = case_view_item,
-                ls = page == -1 ? result : result.Skip((page - 1) * page_size).Take(page_size).ToList(),
-                page_size = page_size,
-                page = page,
-                total = result.Count
+                id = data.id,
+                user = data.user,
+                search_text = data.search_text,
+                showAll = data.showAll,
+                cv = data.cv,
+                ls = data.ls,
+                page_size = data.page_size,
+                page = data.page,
+                total = data.total
             });
     }
 
     [Route("_audit/{p_id}/detail/{change_id}/{change_item}")]
     public async Task<IActionResult> MoreDetail(System.Threading.CancellationToken cancellationToken, string p_id, string change_id, int change_item)
     {
-
-        var case_view_request_string = $"{db_config.url}/{db_config.prefix}mmrds/_design/sortable/_view/by_id?key=\"{p_id}\"";
-
-        string responseFromServer = await _couchDbHttpClient.ExecuteAsync(
-            "GET",
-            case_view_request_string,
-            null,
-            db_config.user_name,
-            db_config.user_value
-        );
-
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var case_view_response = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.case_view_response>(responseFromServer);
-
-
-        mmria.common.model.couchdb.case_view_sortable_item case_view_item =
-            case_view_response.rows.Where(i => i.id == p_id).FirstOrDefault().value;
-
-
-        //var request_string = $"{configuration["mmria_settings:couchdb_url}/{configuration["mmria_settings:db_prefix}audit/_all_docs?include_docs=true";
-        var request_string = $"{db_config.url}/{db_config.prefix}audit/{change_id}";
-        responseFromServer = await _couchDbHttpClient.ExecuteAsync(
-            "GET",
-            request_string,
-            null,
-            db_config.user_name,
-            db_config.user_value
-        );
-
-        cancellationToken.ThrowIfCancellationRequested();
-
-
-        var cs = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.Change_Stack>(responseFromServer);
-
-
-        for (var i = 0; i < cs.items.Count; i++)
-        {
-            cs.items[i].temp_index = i;
-        }
-
-        string metadata_url = $"{db_config.url}/metadata/version_specification-{cs.metadata_version}/metadata";
-
-        var metadataResponse = await _couchDbHttpClient.ExecuteAsync(
-            "GET",
-            metadata_url,
-            null,
-            null,
-            null
-        );
-        mmria.common.metadata.app metadata = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.metadata.app>(metadataResponse);
-
-        this.lookup = get_look_up(metadata);
-        var node = get_metadata_node(metadata, cs.items[change_item].dictionary_path.Trim().TrimStart('/'));
-        if (node == null)
+        var data = await _auditRecoveryManager.GetAuditDetailDataAsync(p_id, change_id, change_item, db_config, cancellationToken);
+        if (data.value_to_display == null && data.display_to_value == null)
         {
             return View(new Audit_Detail_View()
             {
-                id = p_id,
-                change_id = change_id,
-                cv = case_view_item,
-                cs = cs,
-                change_item = change_item,
-                MetadataNode = metadata.AsNode()
+                id = data.id,
+                change_id = data.change_id,
+                cv = data.cv,
+                cs = data.cs,
+                change_item = data.change_item,
+                MetadataNode = data.MetadataNode
 
 
             });
         }
         else
         {
-            var x = convert(node);
-
             return View(new Audit_Detail_View()
             {
-                id = p_id,
-                change_id = change_id,
-                cv = case_view_item,
-                cs = cs,
-                change_item = change_item,
-                MetadataNode = node,
-                value_to_display = x.value_to_display,
-                display_to_value = x.display_to_value
+                id = data.id,
+                change_id = data.change_id,
+                cv = data.cv,
+                cs = data.cs,
+                change_item = data.change_item,
+                MetadataNode = data.MetadataNode,
+                value_to_display = data.value_to_display,
+                display_to_value = data.display_to_value
 
             });
         }
@@ -643,23 +521,7 @@ public sealed class _auditController : Controller
     {
         try
         {
-            var request_string = $"{db_config.url}/{db_config.prefix}audit/audit-manage-user";
-            string responseFromServer = await _couchDbHttpClient.ExecuteAsync(
-                "GET",
-                request_string,
-                null,
-                db_config.user_name,
-                db_config.user_value
-            );
-
-            // Check if document exists (not a 404 error)
-            if (responseFromServer.Contains("\"error\":\"not_found\""))
-            {
-                return null; // Document doesn't exist yet
-            }
-
-            var result = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.audit.Audit_Manage_User>(responseFromServer);
-            return result;
+            return await _auditRecoveryManager.GetAuditDocumentAsync(db_config);
         }
         catch (Exception ex)
         {
@@ -672,31 +534,7 @@ public sealed class _auditController : Controller
     {
         try
         {
-            // Configure JSON serialization to exclude null values
-            var settings = new Newtonsoft.Json.JsonSerializerSettings
-            {
-                NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore
-            };
-            
-            var object_string = Newtonsoft.Json.JsonConvert.SerializeObject(auditDocument, settings);
-            var request_string = $"{db_config.url}/{db_config.prefix}audit/{auditDocument._id}";
-            
-            Console.WriteLine($"SaveAuditDocument URL: {request_string}");
-            Console.WriteLine($"SaveAuditDocument _rev: {auditDocument._rev ?? "null"}");
-            Console.WriteLine($"SaveAuditDocument Data: {object_string}");
-            
-            string responseFromServer = await _couchDbHttpClient.ExecuteAsync(
-                "PUT",
-                request_string,
-                object_string,
-                db_config.user_name,
-                db_config.user_value
-            );
-            Console.WriteLine($"SaveAuditDocument Response: {responseFromServer}");
-            
-            var result = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.document_put_response>(responseFromServer);
-            
-            return result;
+            return await _auditRecoveryManager.SaveAuditDocumentAsync(auditDocument, db_config);
         }
         catch (Exception ex)
         {

--- a/source-code/mmria/mmria-server/Controllers/api/AuditRecoverUtilController.cs
+++ b/source-code/mmria/mmria-server/Controllers/api/AuditRecoverUtilController.cs
@@ -21,7 +21,7 @@ public sealed class AuditRecoverUtilController: ControllerBase
     common.couchdb.DBConfigurationDetail db_config;
 
     string host_prefix = null;
-    private readonly mmria.common.getset.CouchDbHttpClient _couchDbHttpClient;
+    private readonly mmria.common.SharedLibraries.AuditRecovery.Manager.AuditRecoveryManager _auditRecoveryManager;
     
     private Dictionary<string,mmria.common.metadata.value_node[]> lookup;
     public AuditRecoverUtilController  
@@ -30,10 +30,10 @@ public sealed class AuditRecoverUtilController: ControllerBase
         mmria.common.couchdb.OverridableConfiguration _configuration,
         List<mmria.common.couchdb.OverridableConfiguration> overridableConfigSets,
         List<mmria.common.couchdb.ConfigurationSet> dbConfigSets,
-        mmria.common.getset.CouchDbHttpClient couchDbHttpClient
+        mmria.common.SharedLibraries.AuditRecovery.Manager.AuditRecoveryManager auditRecoveryManager
     )
     {
-        _couchDbHttpClient = couchDbHttpClient;
+        _auditRecoveryManager = auditRecoveryManager;
         configuration = _configuration;
         _overridableConfigSets = overridableConfigSets;
         _dbConfigSets = dbConfigSets;
@@ -84,72 +84,19 @@ public sealed class AuditRecoverUtilController: ControllerBase
         {
 
             var config = configuration.GetDBConfig(jurisdiction_id);
-
-            var case_view_request_string = $"{config.url}/{config.prefix}mmrds/_design/sortable/_view/by_id?key=\"{case_id}\"";
-
-            string responseFromServer = await _couchDbHttpClient.ExecuteAsync("GET", case_view_request_string, null, config.user_name, config.user_value);
-
-            var case_view_response = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.case_view_response>(responseFromServer);
-
-
-            mmria.common.model.couchdb.case_view_sortable_item case_view_item = 
-                case_view_response.rows.Where(i=> i.id == case_id).FirstOrDefault().value;
-
-
-            //var request_string = $"{configuration.url}/{configuration.prefix}audit/_all_docs?include_docs=true";
-            var (request_string, post_data) = get_find_url(config, case_id);
-            responseFromServer = await _couchDbHttpClient.ExecuteAsync("POST", request_string, post_data, config.user_name, config.user_value);
-
-
-
-            var view_response = Newtonsoft.Json.JsonConvert.DeserializeObject<Change_Stack_Result_Struct>(responseFromServer);
-
-            List<mmria.common.model.couchdb.Change_Stack> result = new();
-
-            foreach(var item in view_response.docs)
-            {
-
-                for(var i = 0; i < item.items.Count; i++)
-                {
-                    item.items[i].temp_index = i;
-                }
-
-                for(var subitem_index = 0; subitem_index < item.items.Count; subitem_index++)
-                {
-                    var subitem = item.items[subitem_index];
-
-
-
-                }
-
-                item.items.Sort(new Change_Stack_Item_DescendingDate());
-                
-                if(showAll)
-                {
-                    result.Add(DebounceDateTimeField(item));
-                }
-                else if(item.items.Count > 0 && item.case_id == case_id)
-                {
-                    
-                    result.Add(DebounceDateTimeField(item));
-                }
-            }
-
-            const int page_size = 50;
-            
-            result.Sort(new Change_Stack_DescendingDate());
+            var data = await _auditRecoveryManager.GetAuditViewDataAsync(case_id, page, user, search_text, showAll, config, cancellationToken);
             return 
                 new Audit_View()
                 {
-                    id = case_id,
-                    user = user,
-                    search_text = search_text,
-                    showAll = showAll,
-                    cv = case_view_item, 
-                    ls = page == -1? result : result.Skip((page-1) * page_size).Take(page_size).ToList(),
-                    page_size = page_size,
-                    page = page,
-                    total = result.Count
+                    id = data.id,
+                    user = data.user,
+                    search_text = data.search_text,
+                    showAll = data.showAll,
+                    cv = data.cv, 
+                    ls = data.ls,
+                    page_size = data.page_size,
+                    page = data.page,
+                    total = data.total
                 };
         }
         catch(Exception ex)

--- a/source-code/mmria/mmria-server/Controllers/api/caseRevisionController.cs
+++ b/source-code/mmria/mmria-server/Controllers/api/caseRevisionController.cs
@@ -29,7 +29,7 @@ public sealed class caseRevisionController: ControllerBase
     common.couchdb.DBConfigurationDetail db_config;
 
     string host_prefix = null;
-    private readonly mmria.common.getset.CouchDbHttpClient _couchDbHttpClient;
+    private readonly mmria.common.SharedLibraries.AuditRecovery.Manager.AuditRecoveryManager _auditRecoveryManager;
 
     private readonly IAuthorizationService _authorizationService;
     //private readonly IDocumentRepository _documentRepository;
@@ -42,14 +42,14 @@ public sealed class caseRevisionController: ControllerBase
         mmria.common.couchdb.OverridableConfiguration _configuration,
         List<mmria.common.couchdb.OverridableConfiguration> overridableConfigSets,
         List<mmria.common.couchdb.ConfigurationSet> dbConfigSets,
-        mmria.common.getset.CouchDbHttpClient couchDbHttpClient
+        mmria.common.SharedLibraries.AuditRecovery.Manager.AuditRecoveryManager auditRecoveryManager
     )
     {
         _actorSystem = actorSystem;
         _authorizationService = authorizationService;
         _overridableConfigSets = overridableConfigSets;
         _dbConfigSets = dbConfigSets;
-        _couchDbHttpClient = couchDbHttpClient;
+        _auditRecoveryManager = auditRecoveryManager;
         host_prefix = httpContextAccessor.HttpContext.Request.Host.GetPrefix();
 
         configuration = mmria.server.util.MultiTenantConfigHelper.GetConfigurationForTenant(_overridableConfigSets, _configuration, host_prefix);
@@ -64,24 +64,9 @@ public sealed class caseRevisionController: ControllerBase
         {
             var config = configuration.GetDBConfig(jurisdiction_id);
 
-            string all_revs_url = $"{config.url}/{config.prefix}mmrds/{case_id}?rev={revision_id}";
-
             if (!string.IsNullOrWhiteSpace (case_id)) 
             {
-
-                string responseFromServer = await _couchDbHttpClient.ExecuteAsync(
-                    "GET",
-                    all_revs_url,
-                    null,
-                    config.user_name,
-                    config.user_value
-                );
-
-               
-                
-                var result = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Dynamic.ExpandoObject>(responseFromServer);
-
-                return result;
+                return await _auditRecoveryManager.GetCaseRevisionAsync(case_id, revision_id, config);
 
             } 
 
@@ -106,182 +91,6 @@ public sealed class caseRevisionController: ControllerBase
     { 
 
         return null;
-
-        /*
-
-        var case_post_request = save_case_request.Case_Data;
-
-        string auth_session_token = null;
-
-        string object_string = null;
-        mmria.common.model.couchdb.document_put_response result = new mmria.common.model.couchdb.document_put_response ();
-
-
-        try
-        {
-
-            var config = ConfigDB.detail_list[jurisdiction_id];
-
-            var userName = "";
-            if (User.Identities.Any(u => u.IsAuthenticated))
-            {
-                userName = User.Identities.First(
-                    u => u.IsAuthenticated && 
-                    u.HasClaim(c => c.Type == System.Security.Claims.ClaimTypes.Name)).FindFirst(System.Security.Claims.ClaimTypes.Name).Value;
-            }
-
-            var byName = (IDictionary<string,object>)case_post_request;
-            var created_by = byName["created_by"] as string;
-            if(string.IsNullOrWhiteSpace(created_by))
-            {
-                byName["created_by"] = userName;
-            } 
-
-            if(byName.ContainsKey("last_updated_by"))
-            {
-                byName["last_updated_by"] = userName;
-            }
-            else
-            {
-                byName.Add("last_updated_by", userName);
-                
-            }
-
-
-            Newtonsoft.Json.JsonSerializerSettings settings = new Newtonsoft.Json.JsonSerializerSettings ();
-            settings.NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore;
-            object_string = Newtonsoft.Json.JsonConvert.SerializeObject(case_post_request, settings);
-
-            
-            var temp_id = byName["_id"]; 
-            string id_val = null;
-
-            if(temp_id is DateTime)
-            {
-                id_val = string.Concat(((DateTime)temp_id).ToString("s"), "Z");
-            }
-            else
-            {
-                id_val = temp_id.ToString();
-            }
-
-
-
-            var home_record = (IDictionary<string,object>)byName["home_record"];
-            if(!home_record.ContainsKey("jurisdiction_id"))
-            {
-                home_record.Add("jurisdiction_id", "/");
-            }
-
-            if(!mmria.common.utils.authorization_case.is_authorized_to_handle_jurisdiction_id(User, mmria.common.SharedLibraries.Other.ResourceRightEnum.WriteCase, home_record["jurisdiction_id"].ToString()))
-            {
-                Console.Write($"unauthorized PUT {home_record["jurisdiction_id"]}: {byName["_id"]}");
-                return result;
-            }
-
-
-            // begin - check if doc exists
-            try 
-            {
-                string check_document_json = await _couchDbHttpClient.ExecuteAsync(
-                    "GET",
-                    $"{db_config.url}/{db_config.prefix}mmrds/{id_val}",
-                    null,
-                    db_config.user_name,
-                    db_config.user_value
-                );
-                var check_document_expando_object = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Dynamic.ExpandoObject> (check_document_json);
-                IDictionary<string, object> result_dictionary = check_document_expando_object as IDictionary<string, object>;
-
-                if
-                (
-                    result_dictionary != null && 
-                    !mmria.common.utils.authorization_case.is_authorized_to_handle_jurisdiction_id(User, mmria.common.SharedLibraries.Other.ResourceRightEnum.WriteCase, check_document_expando_object)
-                )
-                {
-                    Console.Write($"unauthorized PUT {result_dictionary["jurisdiction_id"]}: {result_dictionary["_id"]}");
-                    return result;
-                }
-
-            } 
-            catch (Exception ex) 
-            {
-                // do nothing for now document doesn't exsist.
-                System.Console.WriteLine ($"err caseRevisionController.Post\n{ex}");
-            }
-            // end - check if doc exists
-
-
-
-
-            try
-            {
-                string metadata_url = $"{db_config.url}/{db_config.prefix}mmrds/{id_val}";
-                string responseFromServer = await _couchDbHttpClient.ExecuteAsync(
-                    "PUT",
-                    metadata_url,
-                    object_string,
-                    db_config.user_name,
-                    db_config.user_value
-                );
-                result = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.document_put_response>(responseFromServer);
-            }
-            catch(Exception ex)
-            {
-                Console.Write("auth_session_token: {0}", auth_session_token);
-                Console.WriteLine(ex);
-            }
-
-
-            var audit_data = save_case_request.Change_Stack;
-
-            var audit_string = Newtonsoft.Json.JsonConvert.SerializeObject(audit_data, settings);
-
-            try
-            {
-                string audit_url = $"{db_config.url}/{db_config.prefix}audit/{audit_data._id}";
-                string responseFromServer = await _couchDbHttpClient.ExecuteAsync(
-                    "PUT",
-                    audit_url,
-                    audit_string,
-                    db_config.user_name,
-                    db_config.user_value
-                );
-                var audit_result = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.document_put_response>(responseFromServer);
-            }
-            catch(Exception ex)
-            {
-                Console.Write("problem saving audit\n{0}", ex);
-
-            }
-
-            var Sync_Document_Message = new mmria.server.model.actor.Sync_Document_Message
-            (
-                id_val,
-                    object_string
-            );
-
-            _actorSystem.ActorOf(Props.Create<mmria.server.model.actor.Synchronize_Case>(db_config, _couchDbHttpClient, configuration, host_prefix)).Tell(Sync_Document_Message);
-    
-            /*
-            var case_sync_actor = _actorSystem.ActorSelection("akka://mmria-actor-system/user/case_sync_actor");
-            case_sync_actor.Tell(Sync_Document_Message);
-            * /
-            if (!result.ok)
-            {
-
-            }
-
-        }
-        catch(Exception ex) 
-        {
-            Console.Write("auth_session_token: {0}", auth_session_token);
-            Console.WriteLine (ex);
-        }
-
-        return result;
-        */
-
     } 
 
     

--- a/source-code/mmria/mmria-server/Controllers/api/checkcodeController.cs
+++ b/source-code/mmria/mmria-server/Controllers/api/checkcodeController.cs
@@ -17,19 +17,19 @@ public sealed class checkcodeController: ControllerBase
     List<mmria.common.couchdb.ConfigurationSet> _dbConfigSets;
     common.couchdb.DBConfigurationDetail db_config;
     string host_prefix = null;
-    private readonly mmria.common.getset.CouchDbHttpClient _couchDbHttpClient;
+    private readonly mmria.common.SharedLibraries.MetadataVersion.Manager.MetadataVersionManager _metadataVersionManager;
     public checkcodeController
     (
         IHttpContextAccessor httpContextAccessor, 
         mmria.common.couchdb.OverridableConfiguration _configuration,
         List<mmria.common.couchdb.OverridableConfiguration> overridableConfigSets,
         List<mmria.common.couchdb.ConfigurationSet> dbConfigSets,
-        mmria.common.getset.CouchDbHttpClient couchDbHttpClient
+        mmria.common.SharedLibraries.MetadataVersion.Manager.MetadataVersionManager metadataVersionManager
     )
     {
         _overridableConfigSets = overridableConfigSets;
         _dbConfigSets = dbConfigSets;
-        _couchDbHttpClient = couchDbHttpClient;
+        _metadataVersionManager = metadataVersionManager;
         host_prefix = httpContextAccessor.HttpContext.Request.Host.GetPrefix();
 
         configuration = mmria.server.util.MultiTenantConfigHelper.GetConfigurationForTenant(_overridableConfigSets, _configuration, host_prefix);
@@ -45,17 +45,7 @@ public sealed class checkcodeController: ControllerBase
 
         try
         {
-            //"2016-06-12T13:49:24.759Z"
-            string request_string = db_config.url + $"/metadata/2016-06-12T13:49:24.759Z/mmria-check-code.js";
-
-            result = await _couchDbHttpClient.ExecuteAsync(
-                "GET",
-                request_string,
-                null,
-                null,
-                null
-            );
-
+            result = await _metadataVersionManager.GetCheckCodeAsync(db_config);
         }
         catch(Exception ex) 
         {
@@ -96,29 +86,7 @@ public sealed class checkcodeController: ControllerBase
                 check_code_json = await reader0.ReadToEndAsync ();
                 */
 
-                string metadata_url = db_config.url + "/metadata/2016-06-12T13:49:24.759Z/mmria-check-code.js";
-
-                var revision = await get_revision(db_config.url + "/metadata/2016-06-12T13:49:24.759Z");
-
-                var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                if (!string.IsNullOrWhiteSpace(revision))
-                {
-                    headers["If-Match"] = revision;
-                }
-                string responseFromServer = await _couchDbHttpClient.ExecuteAsync(
-                    "PUT",
-                    metadata_url,
-                    check_code_json,
-                    db_config.user_name,
-                    db_config.user_value,
-                    "text/*",
-                    headers
-                );
-
-                Console.Write("checkCodeController.Put");
-                Console.Write(responseFromServer);
-
-                result = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.document_put_response>(responseFromServer);
+                result = await _metadataVersionManager.SaveCheckCodeAsync(check_code_json, db_config);
 
                 if (!result.ok) 
                 {
@@ -133,43 +101,6 @@ public sealed class checkcodeController: ControllerBase
             
         return result;
     } 
-
-    private async System.Threading.Tasks.Task<string> get_revision(string p_document_url)
-    {
-
-        string result = null;
-
-        string temp_document_json = null;
-
-        try
-        {
-            
-            temp_document_json = await _couchDbHttpClient.ExecuteAsync(
-                "GET",
-                p_document_url,
-                null,
-                db_config.user_name,
-                db_config.user_value
-            );
-            var request_result = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Dynamic.ExpandoObject>(temp_document_json);
-            IDictionary<string, object> updater = request_result as IDictionary<string, object>;
-            if(updater != null && updater.ContainsKey("_rev"))
-            {
-                result = updater ["_rev"].ToString ();
-            }
-        }
-        catch(Exception ex) 
-        {
-            if (!(ex.Message.IndexOf ("(404) Object Not Found") > -1)) 
-            {
-                //System.Console.WriteLine ("c_sync_document.get_revision");
-                //System.Console.WriteLine (ex);
-            }
-        }
-
-        return result;
-    }
-
 } 
 
 

--- a/source-code/mmria/mmria-server/Controllers/api/metadataController.cs
+++ b/source-code/mmria/mmria-server/Controllers/api/metadataController.cs
@@ -12,7 +12,7 @@ namespace mmria.server;
 [Route("api/[controller]")]
 public sealed class metadataController: ControllerBase 
 { 
-    private readonly mmria.common.getset.CouchDbHttpClient _couchDbHttpClient;
+    private readonly mmria.common.SharedLibraries.MetadataVersion.Manager.MetadataVersionManager _metadataVersionManager;
     mmria.common.couchdb.OverridableConfiguration configuration;
     List<mmria.common.couchdb.OverridableConfiguration> _overridableConfigSets;
     List<mmria.common.couchdb.ConfigurationSet> _dbConfigSets;
@@ -24,10 +24,10 @@ public sealed class metadataController: ControllerBase
         mmria.common.couchdb.OverridableConfiguration _configuration,
         List<mmria.common.couchdb.OverridableConfiguration> overridableConfigSets,
         List<mmria.common.couchdb.ConfigurationSet> dbConfigSets,
-        mmria.common.getset.CouchDbHttpClient couchDbHttpClient
+        mmria.common.SharedLibraries.MetadataVersion.Manager.MetadataVersionManager metadataVersionManager
     )
     {
-        _couchDbHttpClient = couchDbHttpClient;
+        _metadataVersionManager = metadataVersionManager;
         configuration = _configuration;
         _overridableConfigSets = overridableConfigSets;
         _dbConfigSets = dbConfigSets;
@@ -56,20 +56,7 @@ public sealed class metadataController: ControllerBase
         System.Dynamic.ExpandoObject json_result = null;
         try
         {
-
-            //"2016-06-12T13:49:24.759Z"
-            string request_string = $"{db_config.url}/metadata/2016-06-12T13:49:24.759Z";
-
-            result = await _couchDbHttpClient.ExecuteAsync(
-                "GET",
-                request_string,
-                null,
-                null,
-                null
-            );
-
-            json_result = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Dynamic.ExpandoObject>(result, new  Newtonsoft.Json.Converters.ExpandoObjectConverter());
-
+            json_result = await _metadataVersionManager.GetMetadataAsync(db_config);
         }
         catch(Exception ex) 
         {
@@ -90,18 +77,7 @@ public sealed class metadataController: ControllerBase
         System.Dynamic.ExpandoObject json_result = null;
         try
         {
-            string request_string =  $"{db_config.url}/metadata/{id}";
-
-            result = await _couchDbHttpClient.ExecuteAsync(
-                "GET",
-                request_string,
-                null,
-                null,
-                null
-            );
-
-            json_result = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Dynamic.ExpandoObject>(result, new  Newtonsoft.Json.Converters.ExpandoObjectConverter());
-
+            json_result = await _metadataVersionManager.GetMetadataAsync(id, db_config);
         }
         catch(Exception ex) 
         {
@@ -124,15 +100,7 @@ public sealed class metadataController: ControllerBase
 
         try
         {
-            Newtonsoft.Json.JsonSerializerSettings settings = new Newtonsoft.Json.JsonSerializerSettings ();
-            settings.NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore;
-            object_string = Newtonsoft.Json.JsonConvert.SerializeObject(metadata, settings);
-
-            string metadata_url = $"{db_config.url}/metadata/"  + metadata._id;
-
-            string responseFromServer = await _couchDbHttpClient.ExecuteAsync("PUT", metadata_url, object_string, db_config.user_name, db_config.user_value);
-
-            result = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.document_put_response>(responseFromServer);
+            result = await _metadataVersionManager.SaveMetadataAsync(metadata, db_config);
 
             if (!result.ok) 
             {
@@ -158,16 +126,7 @@ public sealed class metadataController: ControllerBase
 
         try
         {
-            string request_string = $"{db_config.url}/metadata/2016-06-12T13:49:24.759Z/mmria-check-code.js";
-
-            result = await _couchDbHttpClient.ExecuteAsync(
-                "GET",
-                request_string,
-                null,
-                null,
-                null
-            );
-
+            result = await _metadataVersionManager.GetCheckCodeAsync(db_config);
         }
         catch(Exception ex) 
         {
@@ -196,20 +155,7 @@ public sealed class metadataController: ControllerBase
 
             check_code_json = await reader0.ReadToEndAsync ();
 
-            string metadata_url = $"{db_config.url}/metadata/2016-06-12T13:49:24.759Z/mmria-check-code.js";
-
-            var revision = await get_revision(db_config.url + "/metadata/2016-06-12T13:49:24.759Z");
-            string responseFromServer;
-            if (!string.IsNullOrWhiteSpace(revision))
-            {
-                responseFromServer = await _couchDbHttpClient.ExecuteAsync("PUT", metadata_url, check_code_json, db_config.user_name, db_config.user_value, "text/*", new Dictionary<string, string> { { "If-Match", revision } });
-            }
-            else
-            {
-                responseFromServer = await _couchDbHttpClient.ExecuteAsync("PUT", metadata_url, check_code_json, db_config.user_name, db_config.user_value, "text/*");
-            }
-
-            result = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.document_put_response>(responseFromServer);
+            result = await _metadataVersionManager.SaveCheckCodeAsync(check_code_json, db_config);
 
             if (!result.ok) 
             {
@@ -251,16 +197,7 @@ public sealed class metadataController: ControllerBase
         try
         {
 
-            Newtonsoft.Json.JsonSerializerSettings settings = new Newtonsoft.Json.JsonSerializerSettings{
-                    NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
-                    MissingMemberHandling =  Newtonsoft.Json.MissingMemberHandling.Ignore
-            };
-            string json_string = Newtonsoft.Json.JsonConvert.SerializeObject(p_version_specification, settings);
-            string metadata_url = $"{db_config.url}/metadata/{p_version_specification._id}";
-
-            string responseFromServer = await _couchDbHttpClient.ExecuteAsync("PUT", metadata_url, json_string, db_config.user_name, db_config.user_value);
-
-            result = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.document_put_response>(responseFromServer);
+            result = await _metadataVersionManager.SaveMetadataVersionSpecificationAsync(p_version_specification, db_config);
 
             if (!result.ok) 
             {
@@ -273,36 +210,6 @@ public sealed class metadataController: ControllerBase
             Console.WriteLine (ex);
         }
         
-        return result;
-    }
-
-    private async System.Threading.Tasks.Task<string> get_revision(string p_document_url)
-    {
-
-        string result = null;
-
-        string temp_document_json = null;
-
-        try
-        {
-            
-            temp_document_json = await _couchDbHttpClient.ExecuteAsync("GET", p_document_url, null, db_config.user_name, db_config.user_value);
-            var request_result = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Dynamic.ExpandoObject>(temp_document_json);
-            IDictionary<string, object> updater = request_result as IDictionary<string, object>;
-            if(updater != null && updater.ContainsKey("_rev"))
-            {
-                result = updater ["_rev"].ToString ();
-            }
-        }
-        catch(Exception ex) 
-        {
-            if (!(ex.Message.IndexOf ("(404) Object Not Found") > -1)) 
-            {
-                //System.Console.WriteLine ("c_sync_document.get_revision");
-                //System.Console.WriteLine (ex);
-            }
-        }
-
         return result;
     }
 

--- a/source-code/mmria/mmria-server/Controllers/api/ui_specificationController.cs
+++ b/source-code/mmria/mmria-server/Controllers/api/ui_specificationController.cs
@@ -19,17 +19,17 @@ public sealed class ui_specificationController: ControllerBase
     List<mmria.common.couchdb.ConfigurationSet> _dbConfigSets;
     common.couchdb.DBConfigurationDetail db_config;
     string host_prefix = null;
-    private readonly mmria.common.getset.CouchDbHttpClient _couchDbHttpClient;
+    private readonly mmria.common.SharedLibraries.MetadataVersion.Manager.MetadataVersionManager _metadataVersionManager;
     public ui_specificationController
     (
         IHttpContextAccessor httpContextAccessor, 
         mmria.common.couchdb.OverridableConfiguration _configuration,
         List<mmria.common.couchdb.OverridableConfiguration> overridableConfigSets,
         List<mmria.common.couchdb.ConfigurationSet> dbConfigSets,
-        mmria.common.getset.CouchDbHttpClient couchDbHttpClient
+        mmria.common.SharedLibraries.MetadataVersion.Manager.MetadataVersionManager metadataVersionManager
     )
     {
-        _couchDbHttpClient = couchDbHttpClient;
+        _metadataVersionManager = metadataVersionManager;
         configuration = _configuration;
         _overridableConfigSets = overridableConfigSets;
         _dbConfigSets = dbConfigSets;
@@ -49,33 +49,7 @@ public sealed class ui_specificationController: ControllerBase
 
         try
         {
-            string ui_specification_url = db_config.url + $"/metadata/_all_docs?include_docs=true";
-
-            string responseFromServer = await _couchDbHttpClient.ExecuteAsync("GET", ui_specification_url, null, db_config.user_name, db_config.user_value);
-
-            Newtonsoft.Json.JsonSerializerSettings settings = new Newtonsoft.Json.JsonSerializerSettings{
-                    NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
-                    MissingMemberHandling =  Newtonsoft.Json.MissingMemberHandling.Ignore
-            };
-            var ui_specification_list = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.get_response_header<mmria.common.metadata.UI_Specification>> (responseFromServer, settings);
-
-            foreach(var row in ui_specification_list.rows)
-            {
-                var ui_specification = row.doc;
-                if
-                (
-                    ui_specification.data_type == null || 
-                    ui_specification.data_type != "ui-specification"|| 
-                    ui_specification._id == "2016-06-12T13:49:24.759Z" ||
-                    ui_specification._id == "de-identified-list"
-                )
-                {
-                    continue;
-                }
-                result.Add(row.doc);
-                    
-            }
-
+            result = await _metadataVersionManager.ListUiSpecificationsAsync(db_config);
         }
         catch(Exception ex) 
         {
@@ -97,16 +71,7 @@ public sealed class ui_specificationController: ControllerBase
 
         try
         {
-            string ui_specification_url = db_config.url + $"/metadata/" + id;
-            
-            string responseFromServer = await _couchDbHttpClient.ExecuteAsync("GET", ui_specification_url, null, db_config.user_name, db_config.user_value);
-
-            Newtonsoft.Json.JsonSerializerSettings settings = new Newtonsoft.Json.JsonSerializerSettings{
-                    NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
-                    MissingMemberHandling =  Newtonsoft.Json.MissingMemberHandling.Ignore
-            };
-            result = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.metadata.UI_Specification> (responseFromServer, settings);
-
+            result = await _metadataVersionManager.GetUiSpecificationAsync(id, db_config);
         }
         catch(Exception ex) 
         {
@@ -143,24 +108,7 @@ public sealed class ui_specificationController: ControllerBase
                 return null;
             }
 
-            Newtonsoft.Json.JsonSerializerSettings settings = new Newtonsoft.Json.JsonSerializerSettings{
-                    NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
-                    MissingMemberHandling =  Newtonsoft.Json.MissingMemberHandling.Ignore
-            };
-            ui_specification_json = Newtonsoft.Json.JsonConvert.SerializeObject(ui_specification, settings);
-
-            string ui_specification_url = db_config.url + "/metadata/" + ui_specification._id;
-
-
-            try
-            {
-                string responseFromServer = await _couchDbHttpClient.ExecuteAsync("PUT", ui_specification_url, ui_specification_json, db_config.user_name, db_config.user_value);
-                result = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.document_put_response>(responseFromServer);
-            }
-            catch(Exception ex)
-            {
-                Log.Information ($"jurisdiction_treeController:{ex}");
-            }
+            result = await _metadataVersionManager.SaveUiSpecificationAsync(ui_specification, db_config);
 
 
             if (!result.ok) 
@@ -184,36 +132,7 @@ public sealed class ui_specificationController: ControllerBase
     { 
         try
         {
-            string request_string = null;
-
-            if (
-                    !string.IsNullOrWhiteSpace (_id) &&
-                    !string.IsNullOrWhiteSpace (rev)
-                    && _id != "default-ui-specification"
-            ) 
-            {
-                request_string = db_config.url + "/metadata/" + _id + "?rev=" + rev;
-            }
-            else 
-            {
-                return null;
-            }
-
-
-            if
-            (
-                _id == "2016-06-12T13:49:24.759Z" ||
-                _id == "de-identified-list"
-            )
-            {
-                return null;
-            }
-
-
-            string responseFromServer = await _couchDbHttpClient.ExecuteAsync("DELETE", request_string, null, db_config.user_name, db_config.user_value);
-            var result = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Dynamic.ExpandoObject> (responseFromServer);
-
-            return result;
+            return await _metadataVersionManager.DeleteUiSpecificationAsync(_id, rev, db_config);
 
         }
         catch(Exception ex)

--- a/source-code/mmria/mmria-server/Controllers/api/validatorController.cs
+++ b/source-code/mmria/mmria-server/Controllers/api/validatorController.cs
@@ -19,17 +19,17 @@ public sealed class validatorController: ControllerBase
     List<mmria.common.couchdb.ConfigurationSet> _dbConfigSets;
     common.couchdb.DBConfigurationDetail db_config;
     string host_prefix = null;
-    private readonly mmria.common.getset.CouchDbHttpClient _couchDbHttpClient;
+    private readonly mmria.common.SharedLibraries.MetadataVersion.Manager.MetadataVersionManager _metadataVersionManager;
     public validatorController
     (
         IHttpContextAccessor httpContextAccessor, 
         mmria.common.couchdb.OverridableConfiguration _configuration,
         List<mmria.common.couchdb.OverridableConfiguration> overridableConfigSets,
         List<mmria.common.couchdb.ConfigurationSet> dbConfigSets,
-        mmria.common.getset.CouchDbHttpClient couchDbHttpClient
+        mmria.common.SharedLibraries.MetadataVersion.Manager.MetadataVersionManager metadataVersionManager
     )
     {
-        _couchDbHttpClient = couchDbHttpClient;
+        _metadataVersionManager = metadataVersionManager;
         configuration = _configuration;
         _overridableConfigSets = overridableConfigSets;
         _dbConfigSets = dbConfigSets;
@@ -47,15 +47,7 @@ public sealed class validatorController: ControllerBase
 
         try
         {
-            string request_string = db_config.url + $"/metadata/2016-06-12T13:49:24.759Z/validator.js";
-
-            string responseString = await _couchDbHttpClient.ExecuteAsync(
-                "GET",
-                request_string,
-                null,
-                null,
-                null
-            );
+            string responseString = await _metadataVersionManager.GetValidatorAsync(db_config);
             
             byte[] responseBytes = System.Text.Encoding.UTF8.GetBytes(responseString);
             result = File(responseBytes, "application/javascript", "validator");
@@ -101,64 +93,9 @@ public sealed class validatorController: ControllerBase
             // Read the content.
             string validator_js_text = await reader0.ReadToEndAsync ();
 
-            string metadata_url = db_config.url + "/metadata/2016-06-12T13:49:24.759Z/validator.js";
-
-            var revision = await get_revision(db_config.url + "/metadata/2016-06-12T13:49:24.759Z");
-
-            var headerDict = new Dictionary<string, string>();
-
-
-/*
-            System.Net.WebRequest request = System.Net.WebRequest.Create(new System.Uri(metadata_url));
-            request.Method = "PUT";
-            request.ContentType = "text/*";
-            request.ContentLength = validator_js_text.Length;
-            request.PreAuthenticate = false;
-
-            if (!string.IsNullOrWhiteSpace(this.Request.Cookies["AuthSession"]))
-            {
-                string auth_session_value = this.Request.Cookies["AuthSession"];
-                request.Headers.Add("Cookie", "AuthSession=" + auth_session_value);
-                request.Headers.Add("X-CouchDB-WWW-Authenticate", auth_session_value);
-                request.Headers.Add("X-CouchDB-WWW-Authenticate", auth_session_value);
-            }
-*/
-
-            
-
-            if (!string.IsNullOrWhiteSpace(revision))
-            {
-                headerDict.Add("If-Match", revision);
-                //System.Text.RegularExpressions.Regex rgx = new System.Text.RegularExpressions.Regex("[^a-zA-Z0-9 -]");
-                //string If_Match = rgx.Replace(this.Request.Headers["If-Match"], "");
-                
-            }
-
             try
             {
-
-                /*
-                streamWriter.Write(validator_js_text);
-                streamWriter.Flush();
-                streamWriter.Close();
-
-                System.Net.WebResponse response = (System.Net.HttpWebResponse) await request.GetResponseAsync();
-                System.IO.Stream dataStream = response.GetResponseStream ();
-                System.IO.StreamReader reader = new System.IO.StreamReader (dataStream);
-
-                                    if(response.Headers["Set-Cookie"] != null)
-                {
-                    this.Response.Headers.Add("Set-Cookie", response.Headers["Set-Cookie"]);
-                }
-                    */
-                string responseFromServer = await _couchDbHttpClient.ExecuteAsync("PUT", metadata_url, validator_js_text, db_config.user_name, db_config.user_value, "text/*", headerDict);
-
-                result = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.document_put_response>(responseFromServer);
-
-
-
-            //System.Threading.Tasks.Task.Run( new Action(()=> { var f = new GenerateSwaggerFile(); System.IO.File.WriteAllText(Program.config_file_root_folder + "/api-docs/api.json", f.generate(metadata)); }));
-                
+                result = await _metadataVersionManager.SaveValidatorAsync(validator_js_text, db_config);
             }
             catch(Exception ex)
             {
@@ -181,36 +118,6 @@ public sealed class validatorController: ControllerBase
 
         return result;
     } 
-
-    private async System.Threading.Tasks.Task<string> get_revision(string p_document_url)
-    {
-
-        string result = null;
-
-        string temp_document_json = null;
-
-        try
-        {
-            
-            temp_document_json = await _couchDbHttpClient.ExecuteAsync("GET", p_document_url, null, db_config.user_name, db_config.user_value);
-            var request_result = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Dynamic.ExpandoObject>(temp_document_json);
-            IDictionary<string, object> updater = request_result as IDictionary<string, object>;
-            if(updater != null && updater.ContainsKey("_rev"))
-            {
-                result = updater ["_rev"].ToString ();
-            }
-        }
-        catch(Exception ex) 
-        {
-            if (!(ex.Message.IndexOf ("(404) Object Not Found") > -1)) 
-            {
-                //System.Console.WriteLine ("c_sync_document.get_revision");
-                //System.Console.WriteLine (ex);
-            }
-        }
-
-        return result;
-    }
 } 
 
 

--- a/source-code/mmria/mmria-server/Controllers/api/versionController.cs
+++ b/source-code/mmria/mmria-server/Controllers/api/versionController.cs
@@ -23,6 +23,7 @@ public sealed class versionController: ControllerBase
     List<mmria.common.couchdb.ConfigurationSet> _dbConfigSets;
     common.couchdb.DBConfigurationDetail db_config;
     string host_prefix = null;
+    private readonly mmria.common.SharedLibraries.MetadataVersion.Manager.MetadataVersionManager _metadataVersionManager;
     private readonly mmria.common.getset.CouchDbHttpClient _couchDbHttpClient;
     public Dictionary<string, string> formName = new Dictionary<string, string>();
     public versionController
@@ -31,10 +32,12 @@ public sealed class versionController: ControllerBase
         mmria.common.couchdb.OverridableConfiguration _configuration,
         List<mmria.common.couchdb.OverridableConfiguration> overridableConfigSets,
         List<mmria.common.couchdb.ConfigurationSet> dbConfigSets,
-        mmria.common.getset.CouchDbHttpClient couchDbHttpClient
+        mmria.common.getset.CouchDbHttpClient couchDbHttpClient,
+        mmria.common.SharedLibraries.MetadataVersion.Manager.MetadataVersionManager metadataVersionManager
     )
     {
         _couchDbHttpClient = couchDbHttpClient;
+        _metadataVersionManager = metadataVersionManager;
         configuration = _configuration;
         _overridableConfigSets = overridableConfigSets;
         _dbConfigSets = dbConfigSets;
@@ -70,33 +73,7 @@ public sealed class versionController: ControllerBase
 
         try
         {
-            string version_specification_url = db_config.url + $"/metadata/_all_docs?include_docs=true";
-
-            string responseFromServer = await _couchDbHttpClient.ExecuteAsync("GET", version_specification_url, null, db_config.user_name, db_config.user_value);
-
-            Newtonsoft.Json.JsonSerializerSettings settings = new Newtonsoft.Json.JsonSerializerSettings{
-                    NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
-                    MissingMemberHandling =  Newtonsoft.Json.MissingMemberHandling.Ignore
-            };
-            var version_specification_list = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.get_response_header<mmria.common.metadata.Version_Specification>> (responseFromServer, settings);
-
-            foreach(var row in version_specification_list.rows)
-            {
-                var version_specification = row.doc;
-                if
-                (
-                    version_specification.data_type == null || 
-                    version_specification.data_type != "version-specification"|| 
-                    version_specification._id == "2016-06-12T13:49:24.759Z" ||
-                    version_specification._id == "de-identified-list"
-                )
-                {
-                    continue;
-                }
-                result.Add(row.doc);
-                    
-            }
-
+            result = await _metadataVersionManager.ListVersionSpecificationsAsync(db_config);
         }
         catch(Exception ex) 
         {
@@ -116,11 +93,7 @@ public sealed class versionController: ControllerBase
 
         try
         {
-            string version_specification_url = db_config.url + $"/metadata/version_specification-{version_specification_id}";
-
-            string responseFromServer = await _couchDbHttpClient.ExecuteAsync("GET", version_specification_url, null, db_config.user_name, db_config.user_value);
-
-            result = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.metadata.Version_Specification>(responseFromServer);
+            result = await _metadataVersionManager.GetVersionSpecificationMetadataAsync(version_specification_id, db_config);
         }
         catch(Exception ex) 
         {
@@ -147,17 +120,7 @@ public sealed class versionController: ControllerBase
 
         try
         {
-            //"2016-06-12T13:49:24.759Z"
-            string request_string = db_config.url + $"/metadata/2016-06-12T13:49:24.759Z/validator.js";
-
-            result = await _couchDbHttpClient.ExecuteAsync(
-                "GET",
-                request_string,
-                null,
-                null,
-                null
-            );
-
+            result = await _metadataVersionManager.GetValidatorAsync(db_config);
         }
         catch(Exception ex) 
         {
@@ -200,15 +163,7 @@ public sealed class versionController: ControllerBase
 
         try
         {
-            string request_string = db_config.url + $"/metadata/version_specification-{version_specification_id}/{document_name}";
-
-            string responseString = await _couchDbHttpClient.ExecuteAsync(
-                "GET",
-                request_string,
-                null,
-                null,
-                null
-            );
+            string responseString = await _metadataVersionManager.GetVersionDocumentAsync(version_specification_id, document_name, db_config);
 
             string type="javascript";
             if(!string.IsNullOrWhiteSpace(document_name))
@@ -274,65 +229,7 @@ public sealed class versionController: ControllerBase
         //if(!string.IsNullOrWhiteSpace(json))
         try
         {
-            string id_val = p_Version_Specification._id;
-
-
-            string check_url = db_config.url + "/metadata/"  + id_val;
-
-            bool save_document = false;
-
-            if(!string.IsNullOrWhiteSpace(p_Version_Specification._rev))
-            {
-                try
-                {
-                    string responseFromServer = await _couchDbHttpClient.ExecuteAsync("GET", check_url, null, db_config.user_name, db_config.user_value);
-                    var check_result = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.metadata.Version_Specification>(responseFromServer);
-
-                    if
-                    (
-                        !string.IsNullOrWhiteSpace(check_result.data_type) &&
-                        check_result.data_type == "version-specification" 
-                    )
-                    {
-                        if(string.IsNullOrWhiteSpace(check_result.data_type))
-                        {
-                            save_document = true;
-                        }
-                        else if(check_result.publish_status != common.metadata.publish_status_enum.final)
-                        {
-                            save_document = true;
-                        }
-                        
-                    }
-                }
-                catch(Exception ex)
-                {
-                    Console.WriteLine(ex);
-                }
-            }
-
-
-            if(save_document)
-            {
-                Newtonsoft.Json.JsonSerializerSettings settings = new Newtonsoft.Json.JsonSerializerSettings ();
-                settings.NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore;
-                var object_string = Newtonsoft.Json.JsonConvert.SerializeObject(p_Version_Specification, settings);
-
-
-                
-                string metadata_url = db_config.url + "/metadata/"  + id_val;
-
-                try
-                {
-                    string responseFromServer = await _couchDbHttpClient.ExecuteAsync("PUT", metadata_url, object_string, db_config.user_name, db_config.user_value);
-                    result = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.document_put_response>(responseFromServer);
-                }
-                catch(Exception ex)
-                {
-                    Console.WriteLine(ex);
-                }
-            }
-
+            result = await _metadataVersionManager.SaveVersionSpecificationAsync(p_Version_Specification, db_config);
         }
         catch(Exception ex)
         {
@@ -429,7 +326,6 @@ public sealed class versionController: ControllerBase
 
 
 
-        string document_content;
         mmria.common.model.couchdb.document_put_response result = new mmria.common.model.couchdb.document_put_response ();
 
             try
@@ -443,35 +339,9 @@ public sealed class versionController: ControllerBase
                 //dataStream0.Seek(0, System.IO.SeekOrigin.Begin);
                 System.IO.StreamReader reader0 = new System.IO.StreamReader (dataStream0);
 
-                document_content = await reader0.ReadToEndAsync ();
-
-
+                var document_content = await reader0.ReadToEndAsync ();
                 add_attachement = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.metadata.Add_Attachement>(document_content);
-
-                if
-                (
-                    //p_version_specification.data_type == null ||
-                    //p_version_specification.data_type != "version-specification" || 
-                    add_attachement._id =="default_version_specification" ||
-                    add_attachement._id == "2016-06-12T13:49:24.759Z" ||
-                    add_attachement._id == "de-identified-list"
-
-                )
-                {
-                    return null;
-                }
-
-
-                
-
-                string metadata_url = db_config.url + $"/metadata/{add_attachement._id}/{add_attachement.doc_name}";
-
-                var headerDict = new Dictionary<string, string>();
-                headerDict.Add("If-Match", add_attachement._rev);
-
-                string responseFromServer = await _couchDbHttpClient.ExecuteAsync("PUT", metadata_url, add_attachement.document_content, db_config.user_name, db_config.user_value, "text/*", headerDict);
-
-                result = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.document_put_response>(responseFromServer);
+                result = await _metadataVersionManager.SaveVersionAttachmentAsync(add_attachement, db_config, false);
 
                 if (!result.ok) 
                 {

--- a/source-code/mmria/mmria-server/Controllers/api/version_attachController.cs
+++ b/source-code/mmria/mmria-server/Controllers/api/version_attachController.cs
@@ -20,17 +20,17 @@ public sealed class version_attachController: ControllerBase
     List<mmria.common.couchdb.ConfigurationSet> _dbConfigSets;
     common.couchdb.DBConfigurationDetail db_config;
     string host_prefix = null;
-    private readonly mmria.common.getset.CouchDbHttpClient _couchDbHttpClient;
+    private readonly mmria.common.SharedLibraries.MetadataVersion.Manager.MetadataVersionManager _metadataVersionManager;
     public version_attachController
 	(
         IHttpContextAccessor httpContextAccessor, 
         mmria.common.couchdb.OverridableConfiguration _configuration,
         List<mmria.common.couchdb.OverridableConfiguration> overridableConfigSets,
         List<mmria.common.couchdb.ConfigurationSet> dbConfigSets,
-        mmria.common.getset.CouchDbHttpClient couchDbHttpClient
+        mmria.common.SharedLibraries.MetadataVersion.Manager.MetadataVersionManager metadataVersionManager
     )
     {
-        _couchDbHttpClient = couchDbHttpClient;
+        _metadataVersionManager = metadataVersionManager;
         configuration = _configuration;
         _overridableConfigSets = overridableConfigSets;
         _dbConfigSets = dbConfigSets;
@@ -99,69 +99,7 @@ public sealed class version_attachController: ControllerBase
                             break;
                     }
                 }
-
-                
-                if
-                (
-                    //p_version_specification.data_type == null ||
-                    //p_version_specification.data_type != "version-specification" || 
-                    add_attachement._id =="default_ui_specification" ||
-                    add_attachement._id == "2016-06-12T13:49:24.759Z" ||
-                    add_attachement._id == "de-identified-list"
-
-                )
-                {
-                    return null;
-                }
-
-                string check_url = db_config.url + "/metadata/"  + add_attachement._id;
-
-                bool save_document = false;
-
-                try
-                {
-                    string responseFromServer = await _couchDbHttpClient.ExecuteAsync("GET", check_url, null, db_config.user_name, db_config.user_value);
-                    var check_result = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.metadata.Version_Specification>(responseFromServer);
-
-                    if
-                    (
-                        !string.IsNullOrWhiteSpace(check_result.data_type) &&
-                        check_result.data_type == "version-specification" 
-                    )
-                    {
-                        if(string.IsNullOrWhiteSpace(check_result.data_type))
-                        {
-                            save_document = true;
-                        }
-                        else if(check_result.publish_status != common.metadata.publish_status_enum.final)
-                        {
-                            save_document = true;
-                        }
-                        
-                    }
-                }
-                catch(Exception ex)
-                {
-                    Console.WriteLine(ex);
-                }
-                
-                if(save_document)
-                {
-
-                    string metadata_url = db_config.url + $"/metadata/{add_attachement._id}/{add_attachement.doc_name}";
-
-                    var headerDict = new Dictionary<string, string>();
-                    headerDict.Add("If-Match", add_attachement._rev);
-
-                    string responseFromServer = await _couchDbHttpClient.ExecuteAsync("PUT", metadata_url, add_attachement.document_content, db_config.user_name, db_config.user_value, "text/*", headerDict);
-
-                    result = Newtonsoft.Json.JsonConvert.DeserializeObject<mmria.common.model.couchdb.document_put_response>(responseFromServer);
-
-                    if (!result.ok) 
-                    {
-
-                    }
-                }
+                result = await _metadataVersionManager.SaveVersionAttachmentAsync(add_attachement, db_config, true);
             }
             catch(Exception ex) 
             {

--- a/source-code/mmria/mmria-server/Controllers/api/version_code_genController.cs
+++ b/source-code/mmria/mmria-server/Controllers/api/version_code_genController.cs
@@ -19,7 +19,7 @@ public sealed class version_code_genController: ControllerBase
     List<mmria.common.couchdb.ConfigurationSet> _dbConfigSets;
     common.couchdb.DBConfigurationDetail db_config;
     string host_prefix = null;
-    private readonly mmria.common.getset.CouchDbHttpClient _couchDbHttpClient;
+    private readonly mmria.common.SharedLibraries.MetadataVersion.Manager.MetadataVersionManager _metadataVersionManager;
 
     public version_code_genController
 	(
@@ -27,7 +27,7 @@ public sealed class version_code_genController: ControllerBase
         mmria.common.couchdb.OverridableConfiguration _configuration,
         List<mmria.common.couchdb.OverridableConfiguration> overridableConfigSets,
         List<mmria.common.couchdb.ConfigurationSet> dbConfigSets,
-        mmria.common.getset.CouchDbHttpClient couchDbHttpClient
+        mmria.common.SharedLibraries.MetadataVersion.Manager.MetadataVersionManager metadataVersionManager
     )
     {
         configuration = _configuration;
@@ -36,7 +36,7 @@ public sealed class version_code_genController: ControllerBase
         host_prefix = httpContextAccessor.HttpContext.Request.Host.GetPrefix();
         configuration = mmria.server.util.MultiTenantConfigHelper.GetConfigurationForTenant(_overridableConfigSets, _configuration, host_prefix);
         db_config = mmria.server.util.MultiTenantConfigHelper.GetDBConfigForTenant(_dbConfigSets, _configuration, host_prefix);
-        _couchDbHttpClient = couchDbHttpClient;
+        _metadataVersionManager = metadataVersionManager;
     }
 
     [AllowAnonymous] 
@@ -47,9 +47,7 @@ public sealed class version_code_genController: ControllerBase
 
         try
         {
-            string request_string = db_config.url + $"/metadata/2016-06-12T13:49:24.759Z/validator.js";
-
-            result = await _couchDbHttpClient.ExecuteAsync("GET", request_string, null, db_config.user_name, db_config.user_value);
+            result = await _metadataVersionManager.GetValidatorAsync(db_config);
         }
         catch(Exception ex) 
         {
@@ -75,15 +73,9 @@ public sealed class version_code_genController: ControllerBase
         {
 
             var byName = (IDictionary<string,object>)code_gen_request;
-            var payload = byName["payload"].ToString(); 
-            //string id_val = null;
-
-
             Newtonsoft.Json.JsonSerializerSettings settings = new Newtonsoft.Json.JsonSerializerSettings ();
             settings.NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore;
             var payload_string = Newtonsoft.Json.JsonConvert.SerializeObject(byName["payload"], settings);
-
-
             generatedFile = await GenerateFileAsync(payload_string);
 
         }
@@ -101,23 +93,20 @@ public sealed class version_code_genController: ControllerBase
 
     async Task<string> GenerateFileAsync(string schemaJson)
     {
-            string result = null;
+        string result = null;
 
-            var schema = await NJsonSchema.JsonSchema.FromJsonAsync(schemaJson);
-            var settings = new NJsonSchema.CodeGeneration.CSharp.CSharpGeneratorSettings()
-            {
-                Namespace = "AwesomeSauce.v1",
-                //ClassStyle = NJsonSchema.CodeGeneration.CSharp.CSharpClassStyle.Inpc 
-                ClassStyle = NJsonSchema.CodeGeneration.CSharp.CSharpClassStyle.Poco,
-                GenerateJsonMethods = true,
-                GenerateDataAnnotations = true
-            };
+        var schema = await NJsonSchema.JsonSchema.FromJsonAsync(schemaJson);
+        var settings = new NJsonSchema.CodeGeneration.CSharp.CSharpGeneratorSettings()
+        {
+            Namespace = "AwesomeSauce.v1",
+            ClassStyle = NJsonSchema.CodeGeneration.CSharp.CSharpClassStyle.Poco,
+            GenerateJsonMethods = true,
+            GenerateDataAnnotations = true
+        };
 
-            var generator = new NJsonSchema.CodeGeneration.CSharp.CSharpGenerator(schema, settings);
-            result = generator.GenerateFile();
-
-//NJsonSchema.CodeGeneration.CSharp.CSharpClassStyle.
-            return result;
+        var generator = new NJsonSchema.CodeGeneration.CSharp.CSharpGenerator(schema, settings);
+        result = generator.GenerateFile();
+        return result;
     }
 
 } 

--- a/source-code/mmria/mmria-server/Program.cs
+++ b/source-code/mmria/mmria-server/Program.cs
@@ -211,6 +211,10 @@ public sealed partial class Program
             builder.Services.AddScoped<mmria.common.SharedLibraries.Account.Manager.AccountManager>();
             builder.Services.AddScoped<mmria.common.SharedLibraries.ManageUsers.DAL.ManageUsersDAL>();
             builder.Services.AddScoped<mmria.common.SharedLibraries.ManageUsers.Manager.ManageUsersManager>();
+            builder.Services.AddScoped<mmria.common.SharedLibraries.MetadataVersion.DAL.MetadataVersionDAL>();
+            builder.Services.AddScoped<mmria.common.SharedLibraries.MetadataVersion.Manager.MetadataVersionManager>();
+            builder.Services.AddScoped<mmria.common.SharedLibraries.AuditRecovery.DAL.AuditRecoveryDAL>();
+            builder.Services.AddScoped<mmria.common.SharedLibraries.AuditRecovery.Manager.AuditRecoveryManager>();
 
             // Register Session Manager (replaces actor-based Post_Session and Record_Session_Event)
             builder.Services.AddScoped<mmria.common.SharedLibraries.Session.Manager.SessionManager>();


### PR DESCRIPTION
- Replaced CouchDbHttpClient with MetadataVersionManager in version_attachController and version_code_genController.
- Simplified logic for saving version attachments by utilizing SaveVersionAttachmentAsync method in MetadataVersionManager.
- Updated dependency injection in Program.cs to include MetadataVersionDAL and MetadataVersionManager.
- Introduced AuditRecoveryDAL and AuditRecoveryManager for handling audit recovery functionalities.
- Added new models and data access layers for audit recovery and metadata versioning.
- Implemented methods for managing metadata versions, including saving, retrieving, and deleting specifications.