### PR TITLE
Implement CDC Population Throttling Settings

### DIFF
--- a/nccdphp-drh-mmria-common/mmria.common/SharedLibraries/MMRIAServices/Manager/MMRIAServicesManager.cs
+++ b/nccdphp-drh-mmria-common/mmria.common/SharedLibraries/MMRIAServices/Manager/MMRIAServicesManager.cs
@@ -1,17 +1,19 @@
 using mmria.common.SharedLibraries.MMRIAServices.DAL;
 using mmria.common.SharedLibraries.MMRIAServices.Helper;
+using mmria.common.SharedLibraries.MMRIAServices.Model;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
+using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace mmria.common.SharedLibraries.MMRIAServices.Manager;
 
 public sealed class MMRIAServicesManager
 {
-    private const int PopulateCdcBatchSize = 100;
-
     private readonly MMRIAServicesDAL _mmriaServicesDal;
     private readonly mmria.common.getset.CouchDbHttpClient _couchDbHttpClient;
     private readonly System.Net.Http.HttpClient _externalHttpClient;
@@ -472,9 +474,13 @@ public sealed class MMRIAServicesManager
     public async Task<(string Name, string Description)> PopulateCDCInstanceManger(
         mmria.common.metadata.Populate_CDC_Instance message,
         mmria.common.couchdb.ConfigurationSet db_config_set,
-        Action<string> progressCallback = null
+        Action<string> progressCallback = null,
+        PopulateCdcThrottleSettings throttleSettings = null
     )
     {
+        throttleSettings ??= PopulateCdcThrottleSettings.CreateDefaults();
+        var copy_settings = throttleSettings.Copy ?? PopulateCdcThrottleSettings.CreateDefaults().Copy;
+
         if (!db_config_set.detail_list.ContainsKey("cdc") && !db_config_set.detail_list.ContainsKey("cdcqa"))
         {
             throw new Exception("Exception: db_config_set.detail_list.key missing for cdc");
@@ -495,8 +501,11 @@ public sealed class MMRIAServicesManager
             db_config_set.detail_list.ContainsKey(item.prefix));
         int processedSourceCount = 0;
         int sourceErrorCount = 0;
+        int bulkWriteErrorCount = 0;
 
-        Console.WriteLine($"[PopulateCDC] Starting populate run. metadata version: {metadata_release_version_name}, target: {cdc_connection.url}");
+        Console.WriteLine(
+            $"[PopulateCDC] Starting populate run. metadata version: {metadata_release_version_name}, " +
+            $"target: {cdc_connection.url}. Copy throttling: {copy_settings.ToLogString()}.");
         progressCallback?.Invoke($"Phase 1 of 2: preparing CDC transfer for {selectedSourceCount} selected jurisdictions.");
         await SetupPopulateCdcDatabases(cdc_connection);
 
@@ -532,64 +541,87 @@ public sealed class MMRIAServicesManager
 
                 var caseIdList = caseIds.ToList();
                 int sourceCopiedCount = 0;
-                for (int index = 0; index < caseIdList.Count; index += PopulateCdcBatchSize)
+                for (int index = 0; index < caseIdList.Count; index += copy_settings.PageSize)
                 {
-                    int batchNumber = (index / PopulateCdcBatchSize) + 1;
-                    var caseBatchIds = caseIdList.Skip(index).Take(PopulateCdcBatchSize).ToList();
+                    int batchNumber = (index / copy_settings.PageSize) + 1;
+                    var caseBatchIds = caseIdList.Skip(index).Take(copy_settings.PageSize).ToList();
                     var caseBatch = await GetPopulateCdcCaseDocuments(db_info, caseBatchIds);
-                    var documentsToSave = new List<string>(caseBatch.Count);
+                    var documentsToSave = new ConcurrentBag<string>();
 
-                    foreach (var case_row in caseBatch)
-                    {
-                        var case_doc = case_row as IDictionary<string, object>;
-                        if
-                        (
-                            case_doc == null ||
-                            !case_doc.ContainsKey("_id") ||
-                            case_doc["_id"] == null ||
-                            case_doc["_id"].ToString().StartsWith("_design", StringComparison.InvariantCultureIgnoreCase)
-                        )
+                    await Parallel.ForEachAsync(
+                        caseBatch,
+                        new ParallelOptions { MaxDegreeOfParallelism = copy_settings.MaxParallelism },
+                        async (case_row, cancellation_token) =>
                         {
-                            continue;
-                        }
+                            var case_doc = case_row as IDictionary<string, object>;
+                            if
+                            (
+                                case_doc == null ||
+                                !case_doc.ContainsKey("_id") ||
+                                case_doc["_id"] == null ||
+                                case_doc["_id"].ToString().StartsWith("_design", StringComparison.InvariantCultureIgnoreCase)
+                            )
+                            {
+                                return;
+                            }
 
-                        var document_json = Newtonsoft.Json.JsonConvert.SerializeObject(case_doc);
-                        var de_identified_json = await DeIdentifyCaseForPopulateCDC(
-                            document_json,
-                            instance_name,
+                            var document_json = Newtonsoft.Json.JsonConvert.SerializeObject(case_doc);
+                            var de_identified_json = await DeIdentifyCaseForPopulateCDC(
+                                document_json,
+                                instance_name,
+                                cdc_connection,
+                                metadata_release_version_name,
+                                resolvedDeIdentifiedPaths
+                            );
+
+                            var de_identified_case = Newtonsoft.Json.JsonConvert.DeserializeObject<ExpandoObject>(de_identified_json);
+                            case_doc["_rev"] = null;
+
+                            var de_identified_dictionary = de_identified_case as IDictionary<string, object>;
+                            if (de_identified_dictionary == null)
+                            {
+                                return;
+                            }
+
+                            ClearPopulateCdcLockFields(de_identified_dictionary);
+
+                            var save_json = Newtonsoft.Json.JsonConvert.SerializeObject(de_identified_dictionary);
+                            documentsToSave.Add(save_json);
+                        });
+
+                    var save_document_list = documentsToSave.ToList();
+
+                    if (save_document_list.Count > 0)
+                    {
+                        var write_result = await BulkSavePopulateCdcDocumentsWithThrottle(
+                            save_document_list,
                             cdc_connection,
-                            metadata_release_version_name,
-                            resolvedDeIdentifiedPaths
-                        );
-
-                        var de_identified_case = Newtonsoft.Json.JsonConvert.DeserializeObject<ExpandoObject>(de_identified_json);
-                        case_doc["_rev"] = null;
-
-                        var de_identified_dictionary = de_identified_case as IDictionary<string, object>;
-                        if (de_identified_dictionary == null)
-                        {
-                            continue;
-                        }
-
-                        ClearPopulateCdcLockFields(de_identified_dictionary);
-
-                        var save_json = Newtonsoft.Json.JsonConvert.SerializeObject(de_identified_dictionary);
-                        documentsToSave.Add(save_json);
+                            copy_settings);
+                        totalCaseCount += write_result.success_count;
+                        sourceCopiedCount += write_result.success_count;
+                        bulkWriteErrorCount += write_result.error_count;
                     }
 
-                    if (documentsToSave.Count > 0)
+                    Console.WriteLine(
+                        $"[PopulateCDC] Jurisdiction '{instance_name}' batch {batchNumber}: fetched {caseBatch.Count} cases " +
+                        $"and wrote {save_document_list.Count} CDC mmrds docs. Bulk write errors so far: {bulkWriteErrorCount}.");
+                    progressCallback?.Invoke(
+                        $"Phase 1 of 2: copied {totalCaseCount} CDC case documents so far. " +
+                        $"Current jurisdiction {instance_name} ({currentSourceNumber} of {selectedSourceCount}): " +
+                        $"{sourceCopiedCount} of {caseIdList.Count} cases copied from the {sourceDatabaseLabel}. " +
+                        $"CDC case database bulk errors: {bulkWriteErrorCount}.");
+
+                    bool has_more_source_batches = index + copy_settings.PageSize < caseIdList.Count;
+                    if (has_more_source_batches && copy_settings.BatchDelayMs > 0)
                     {
-                        await BulkSavePopulateCdcDocuments(documentsToSave, cdc_connection);
-                        totalCaseCount += documentsToSave.Count;
-                        sourceCopiedCount += documentsToSave.Count;
+                        await Task.Delay(copy_settings.BatchDelayMs, cancellationToken: CancellationToken.None);
                     }
-
-                    Console.WriteLine($"[PopulateCDC] Jurisdiction '{instance_name}' batch {batchNumber}: fetched {caseBatch.Count} cases and wrote {documentsToSave.Count} CDC mmrds docs.");
-                    progressCallback?.Invoke($"Phase 1 of 2: copied {totalCaseCount} CDC case documents so far. Current jurisdiction {instance_name} ({currentSourceNumber} of {selectedSourceCount}): {sourceCopiedCount} of {caseIdList.Count} cases copied from the {sourceDatabaseLabel}.");
                 }
 
                 processedSourceCount++;
-                progressCallback?.Invoke($"Phase 1 of 2: completed jurisdiction {instance_name} ({processedSourceCount} of {selectedSourceCount}). Copied {totalCaseCount} CDC case documents so far.");
+                progressCallback?.Invoke(
+                    $"Phase 1 of 2: completed jurisdiction {instance_name} ({processedSourceCount} of {selectedSourceCount}). " +
+                    $"Copied {totalCaseCount} CDC case documents so far. CDC case database bulk errors: {bulkWriteErrorCount}.");
             }
             catch (Exception ex)
             {
@@ -601,9 +633,92 @@ public sealed class MMRIAServicesManager
             }
         }
 
-        Console.WriteLine($"[PopulateCDC] Populate run complete. Wrote {totalCaseCount} CDC mmrds documents to {cdc_connection.url}/mmrds.");
-        progressCallback?.Invoke($"Phase 1 of 2 complete. Wrote {totalCaseCount} CDC case documents. Jurisdiction errors: {sourceErrorCount}. Starting CDC de-identified case database/report database rebuild.");
+        Console.WriteLine(
+            $"[PopulateCDC] Populate run complete. Wrote {totalCaseCount} CDC mmrds documents to {cdc_connection.url}/mmrds. " +
+            $"CDC mmrds bulk write errors: {bulkWriteErrorCount}.");
+        progressCallback?.Invoke(
+            $"Phase 1 of 2 complete. Wrote {totalCaseCount} CDC case documents. " +
+            $"Jurisdiction errors: {sourceErrorCount}. CDC case database bulk errors: {bulkWriteErrorCount}. " +
+            $"Starting CDC de-identified case database/report database rebuild.");
         return ("Finished", $"Wrote {totalCaseCount} CDC case documents.");
+    }
+
+    private static bool IsTransientBulkWriteException(Exception ex)
+    {
+        if (ex == null)
+        {
+            return false;
+        }
+
+        if (ex is HttpRequestException || ex is TaskCanceledException || ex is TimeoutException)
+        {
+            return true;
+        }
+
+        return IsTransientBulkWriteException(ex.InnerException);
+    }
+
+    private async Task<(int success_count, int error_count)> BulkSavePopulateCdcDocumentsWithThrottle(
+        IEnumerable<string> documentJsonList,
+        mmria.common.couchdb.DBConfigurationDetail cdcConnection,
+        PopulateCdcPhaseThrottleSettings settings)
+    {
+        var document_list = documentJsonList?
+            .Where(item => !string.IsNullOrWhiteSpace(item))
+            .ToList() ?? new List<string>();
+
+        if (document_list.Count == 0)
+        {
+            return (0, 0);
+        }
+
+        int effective_chunk_size =
+            settings?.BulkDocChunkSize > 0
+            ? Math.Max(1, settings.BulkDocChunkSize)
+            : document_list.Count;
+        int retry_count = Math.Max(0, settings?.BulkWriteRetryCount ?? 0);
+        int retry_delay_ms = Math.Max(0, settings?.BulkWriteRetryDelayMs ?? 0);
+        int success_count = 0;
+        int error_count = 0;
+
+        for (int offset = 0; offset < document_list.Count; offset += effective_chunk_size)
+        {
+            var chunk = document_list
+                .Skip(offset)
+                .Take(effective_chunk_size)
+                .ToList();
+
+            for (int attempt = 0; ; attempt++)
+            {
+                try
+                {
+                    var results = await BulkSavePopulateCdcDocuments(chunk, cdcConnection);
+                    int chunk_success_count = results.Count(item => item?.ok == true);
+                    success_count += chunk_success_count;
+                    error_count += Math.Max(0, chunk.Count - chunk_success_count);
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    if (!IsTransientBulkWriteException(ex) || attempt >= retry_count)
+                    {
+                        throw;
+                    }
+
+                    int delay_ms = retry_delay_ms * (attempt + 1);
+                    Console.WriteLine(
+                        $"[PopulateCDC] Transient mmrds bulk write failure for '{cdcConnection?.url}'. " +
+                        $"Retry {attempt + 1} of {retry_count} in {delay_ms} ms.\n{ex.Message}");
+
+                    if (delay_ms > 0)
+                    {
+                        await Task.Delay(delay_ms);
+                    }
+                }
+            }
+        }
+
+        return (success_count, error_count);
     }
 
     private static void ClearPopulateCdcLockFields(IDictionary<string, object> caseDoc)

--- a/nccdphp-drh-mmria-common/mmria.common/SharedLibraries/MMRIAServices/Model/PopulateCdcThrottleSettings.cs
+++ b/nccdphp-drh-mmria-common/mmria.common/SharedLibraries/MMRIAServices/Model/PopulateCdcThrottleSettings.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace mmria.common.SharedLibraries.MMRIAServices.Model;
+
+public sealed class PopulateCdcPhaseThrottleSettings
+{
+    public int PageSize { get; init; }
+    public int MaxParallelism { get; init; }
+    public int BulkDocChunkSize { get; init; }
+    public int BatchDelayMs { get; init; }
+    public int BulkWriteRetryCount { get; init; }
+    public int BulkWriteRetryDelayMs { get; init; }
+
+    public string ToLogString()
+    {
+        string chunk_size_label = BulkDocChunkSize <= 0 ? "disabled" : BulkDocChunkSize.ToString();
+        return
+            $"page size {PageSize}, " +
+            $"max parallelism {MaxParallelism}, " +
+            $"bulk doc chunk size {chunk_size_label}, " +
+            $"batch delay {BatchDelayMs} ms, " +
+            $"bulk write retries {BulkWriteRetryCount}, " +
+            $"bulk write retry delay {BulkWriteRetryDelayMs} ms";
+    }
+}
+
+public sealed class PopulateCdcThrottleSettings
+{
+    public PopulateCdcPhaseThrottleSettings Copy { get; init; } = new();
+    public PopulateCdcPhaseThrottleSettings Rebuild { get; init; } = new();
+
+    public static PopulateCdcThrottleSettings CreateDefaults()
+    {
+        return new PopulateCdcThrottleSettings
+        {
+            Copy = new PopulateCdcPhaseThrottleSettings
+            {
+                PageSize = 100,
+                MaxParallelism = 1,
+                BulkDocChunkSize = 0,
+                BatchDelayMs = 0,
+                BulkWriteRetryCount = 0,
+                BulkWriteRetryDelayMs = 0
+            },
+            Rebuild = new PopulateCdcPhaseThrottleSettings
+            {
+                PageSize = 25,
+                MaxParallelism = Math.Max(1, Math.Min(Environment.ProcessorCount, 2)),
+                BulkDocChunkSize = 0,
+                BatchDelayMs = 0,
+                BulkWriteRetryCount = 0,
+                BulkWriteRetryDelayMs = 0
+            }
+        };
+    }
+}

--- a/nccdphp-drh-mmria-services/mmria.services/Actors/populate-cdc-instance/PopulateCDCInstance.cs
+++ b/nccdphp-drh-mmria-services/mmria.services/Actors/populate-cdc-instance/PopulateCDCInstance.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using mmria.common.SharedLibraries.MMRIAServices.DAL;
 using mmria.common.SharedLibraries.MMRIAServices.Manager;
+using mmria.common.SharedLibraries.MMRIAServices.Model;
 
 namespace mmria.services.populate_cdc_instance;
 
@@ -14,13 +15,17 @@ public sealed class PopulateCDCInstance : ReceiveActor
 
     private readonly mmria.common.getset.CouchDbHttpClient _couchDbHttpClient;
     private readonly MMRIAServicesManager _mmriaServicesManager;
+    private readonly PopulateCdcThrottleSettings _populateCdcThrottleSettings;
 
     protected override void PreStart() => Console.WriteLine("Process_Message started");
     protected override void PostStop() => Console.WriteLine("Process_Message stopped");
-    public PopulateCDCInstance(mmria.common.getset.CouchDbHttpClient couchDbHttpClient)
+    public PopulateCDCInstance(
+        mmria.common.getset.CouchDbHttpClient couchDbHttpClient,
+        PopulateCdcThrottleSettings populateCdcThrottleSettings)
     {
         _couchDbHttpClient = couchDbHttpClient;
         _mmriaServicesManager = new MMRIAServicesManager(new MMRIAServicesDAL(_couchDbHttpClient), _couchDbHttpClient);
+        _populateCdcThrottleSettings = populateCdcThrottleSettings ?? PopulateCdcThrottleSettings.CreateDefaults();
         Become(Waiting);
     }
 
@@ -49,7 +54,11 @@ public sealed class PopulateCDCInstance : ReceiveActor
         {
             var db_config_set = mmria.services.vitalsimport.Program.DbConfigSet;
             Action<string> report_progress = description => reply_to.Tell(new Status("Progress", description));
-            var (name, description) = await _mmriaServicesManager.PopulateCDCInstanceManger(message, db_config_set, report_progress);
+            var (name, description) = await _mmriaServicesManager.PopulateCDCInstanceManger(
+                message,
+                db_config_set,
+                report_progress,
+                _populateCdcThrottleSettings);
 
             var cdc_connection = db_config_set.detail_list.ContainsKey("cdc")
                 ? db_config_set.detail_list["cdc"]
@@ -63,7 +72,8 @@ public sealed class PopulateCDCInstance : ReceiveActor
                 cdc_connection,
                 metadata_release_version_name,
                 _couchDbHttpClient,
-                progressCallback: report_progress);
+                progressCallback: report_progress,
+                throttleSettings: _populateCdcThrottleSettings);
 
             await rebuild.executeAsync();
 

--- a/nccdphp-drh-mmria-services/mmria.services/Actors/populate-cdc-instance/PopulateCDCInstanceSupervisor.cs
+++ b/nccdphp-drh-mmria-services/mmria.services/Actors/populate-cdc-instance/PopulateCDCInstanceSupervisor.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using Akka.Actor;
 using mmria.common.ije;
+using mmria.common.SharedLibraries.MMRIAServices.Model;
 
 namespace mmria.services.populate_cdc_instance;
 
@@ -29,12 +30,16 @@ public sealed class PopulateCDCInstanceSupervisor : ReceiveActor
     IConfiguration configuration;
     ILogger logger;
     mmria.common.getset.CouchDbHttpClient _couchDbHttpClient;
+    private readonly PopulateCdcThrottleSettings _populateCdcThrottleSettings;
 
     protected override void PreStart() => Console.WriteLine("Process_Message started");
     protected override void PostStop() => Console.WriteLine("Process_Message stopped");
-    public PopulateCDCInstanceSupervisor(mmria.common.getset.CouchDbHttpClient couchDbHttpClient)
+    public PopulateCDCInstanceSupervisor(
+        mmria.common.getset.CouchDbHttpClient couchDbHttpClient,
+        PopulateCdcThrottleSettings populateCdcThrottleSettings)
     {
         _couchDbHttpClient = couchDbHttpClient;
+        _populateCdcThrottleSettings = populateCdcThrottleSettings ?? PopulateCdcThrottleSettings.CreateDefaults();
         
         //Context.ActorOf<PopulateCDCInstance>("child");
 
@@ -94,7 +99,10 @@ public sealed class PopulateCDCInstanceSupervisor : ReceiveActor
 
             //var processor = Context.ActorSelection("akka://mmria-actor-system/user/populate-cdc-instance-supervisor/child*");
 
-            var processor = Context.ActorOf(Akka.Actor.Props.Create<PopulateCDCInstance>(_couchDbHttpClient));
+            var processor = Context.ActorOf(
+                Akka.Actor.Props.Create<PopulateCDCInstance>(
+                    _couchDbHttpClient,
+                    _populateCdcThrottleSettings));
             
             processor.Tell(message);
 

--- a/nccdphp-drh-mmria-services/mmria.services/Actors/populate-cdc-instance/PopulateCdcThrottleSettingsLoader.cs
+++ b/nccdphp-drh-mmria-services/mmria.services/Actors/populate-cdc-instance/PopulateCdcThrottleSettingsLoader.cs
@@ -1,0 +1,61 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using mmria.common.SharedLibraries.MMRIAServices.Model;
+
+namespace mmria.services.populate_cdc_instance;
+
+public static class PopulateCdcThrottleSettingsLoader
+{
+    public static PopulateCdcThrottleSettings Load(IConfiguration configuration)
+    {
+        var defaults = PopulateCdcThrottleSettings.CreateDefaults();
+
+        return new PopulateCdcThrottleSettings
+        {
+            Copy = new PopulateCdcPhaseThrottleSettings
+            {
+                PageSize = GetConfiguredInteger(configuration, "populate_cdc_copy_page_size", defaults.Copy.PageSize, 1),
+                MaxParallelism = GetConfiguredInteger(configuration, "populate_cdc_copy_max_parallelism", defaults.Copy.MaxParallelism, 1),
+                BulkDocChunkSize = GetConfiguredInteger(configuration, "populate_cdc_copy_bulk_doc_chunk_size", defaults.Copy.BulkDocChunkSize, 0),
+                BatchDelayMs = GetConfiguredInteger(configuration, "populate_cdc_copy_batch_delay_ms", defaults.Copy.BatchDelayMs, 0),
+                BulkWriteRetryCount = GetConfiguredInteger(configuration, "populate_cdc_copy_bulk_write_retry_count", defaults.Copy.BulkWriteRetryCount, 0),
+                BulkWriteRetryDelayMs = GetConfiguredInteger(configuration, "populate_cdc_copy_bulk_write_retry_delay_ms", defaults.Copy.BulkWriteRetryDelayMs, 0)
+            },
+            Rebuild = new PopulateCdcPhaseThrottleSettings
+            {
+                PageSize = GetConfiguredInteger(configuration, "populate_cdc_rebuild_page_size", defaults.Rebuild.PageSize, 1),
+                MaxParallelism = GetConfiguredInteger(configuration, "populate_cdc_rebuild_max_parallelism", defaults.Rebuild.MaxParallelism, 1),
+                BulkDocChunkSize = GetConfiguredInteger(configuration, "populate_cdc_rebuild_bulk_doc_chunk_size", defaults.Rebuild.BulkDocChunkSize, 0),
+                BatchDelayMs = GetConfiguredInteger(configuration, "populate_cdc_rebuild_batch_delay_ms", defaults.Rebuild.BatchDelayMs, 0),
+                BulkWriteRetryCount = GetConfiguredInteger(configuration, "populate_cdc_rebuild_bulk_write_retry_count", defaults.Rebuild.BulkWriteRetryCount, 0),
+                BulkWriteRetryDelayMs = GetConfiguredInteger(configuration, "populate_cdc_rebuild_bulk_write_retry_delay_ms", defaults.Rebuild.BulkWriteRetryDelayMs, 0)
+            }
+        };
+    }
+
+    private static int GetConfiguredInteger(
+        IConfiguration configuration,
+        string key,
+        int defaultValue,
+        int minimumValue,
+        int? maximumValue = null)
+    {
+        string raw_value =
+            configuration?[$"mmria_settings:{key}"] ??
+            configuration?[key];
+
+        if(!int.TryParse(raw_value, out int configured_value))
+        {
+            configured_value = defaultValue;
+        }
+
+        configured_value = Math.Max(minimumValue, configured_value);
+
+        if(maximumValue.HasValue)
+        {
+            configured_value = Math.Min(maximumValue.Value, configured_value);
+        }
+
+        return configured_value;
+    }
+}

--- a/nccdphp-drh-mmria-services/mmria.services/Actors/populate-cdc-instance/c_document_sync_all.cs
+++ b/nccdphp-drh-mmria-services/mmria.services/Actors/populate-cdc-instance/c_document_sync_all.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
+using mmria.common.SharedLibraries.MMRIAServices.Model;
 using Newtonsoft.Json.Linq;
 
 namespace mmria.server.utils;
@@ -96,6 +98,7 @@ public sealed class Report_PowerBI_Index_Struct
     private readonly mmria.common.couchdb.OverridableConfiguration _configuration;
     private readonly string _host_prefix;
     private readonly Action<string> _progressCallback;
+    private readonly PopulateCdcThrottleSettings _throttleSettings;
 
     public c_document_sync_all (
         common.couchdb.DBConfigurationDetail p_connection, 
@@ -103,7 +106,8 @@ public sealed class Report_PowerBI_Index_Struct
         mmria.common.getset.CouchDbHttpClient couchDbHttpClient,
         mmria.common.couchdb.OverridableConfiguration configuration = null,
         string host_prefix = null,
-        Action<string> progressCallback = null
+        Action<string> progressCallback = null,
+        PopulateCdcThrottleSettings throttleSettings = null
     )
     {
         this.connection = p_connection;
@@ -116,6 +120,7 @@ public sealed class Report_PowerBI_Index_Struct
         _configuration = configuration;
         _host_prefix = host_prefix;
         _progressCallback = progressCallback;
+        _throttleSettings = throttleSettings ?? PopulateCdcThrottleSettings.CreateDefaults();
     }
 
     private void ReportProgress(string message)
@@ -284,7 +289,22 @@ public sealed class Report_PowerBI_Index_Struct
         return Math.Max(0, total_rows - design_row_count);
     }
 
-    private async Task<(int success_count, int error_count)> bulk_write_async(string database_name, List<string> document_json_list)
+    private static bool is_transient_bulk_write_exception(Exception ex)
+    {
+        if(ex == null)
+        {
+            return false;
+        }
+
+        if(ex is HttpRequestException || ex is TaskCanceledException || ex is TimeoutException)
+        {
+            return true;
+        }
+
+        return is_transient_bulk_write_exception(ex.InnerException);
+    }
+
+    private async Task<(int success_count, int error_count)> bulk_write_chunk_async(string database_name, List<string> document_json_list)
     {
         if(document_json_list == null || document_json_list.Count == 0)
         {
@@ -310,11 +330,75 @@ public sealed class Report_PowerBI_Index_Struct
         return (results.Count, error_count);
     }
 
+    private async Task<(int success_count, int error_count)> bulk_write_async(
+        string database_name,
+        List<string> document_json_list,
+        int chunk_size,
+        int retry_count,
+        int retry_delay_ms)
+    {
+        if(document_json_list == null || document_json_list.Count == 0)
+        {
+            return (0, 0);
+        }
+
+        int effective_chunk_size =
+            chunk_size <= 0
+            ? document_json_list.Count
+            : Math.Max(1, chunk_size);
+
+        int success_count = 0;
+        int error_count = 0;
+
+        for(int offset = 0; offset < document_json_list.Count; offset += effective_chunk_size)
+        {
+            var chunk = document_json_list
+                .Skip(offset)
+                .Take(effective_chunk_size)
+                .ToList();
+
+            for(int attempt = 0; ; attempt++)
+            {
+                try
+                {
+                    var chunk_result = await bulk_write_chunk_async(database_name, chunk);
+                    success_count += chunk_result.success_count;
+                    error_count += chunk_result.error_count;
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    if(!is_transient_bulk_write_exception(ex) || attempt >= retry_count)
+                    {
+                        throw;
+                    }
+
+                    int delay_ms = Math.Max(0, retry_delay_ms) * (attempt + 1);
+                    System.Console.WriteLine(
+                        $"[PopulateCDC] Transient {database_name} bulk write failure for '{this.couchdb_url}'. " +
+                        $"Retry {attempt + 1} of {retry_count} in {delay_ms} ms.\n{ex.Message}");
+
+                    if(delay_ms > 0)
+                    {
+                        await Task.Delay(delay_ms);
+                    }
+                }
+            }
+        }
+
+        return (success_count, error_count);
+    }
+
 
     public async Task executeAsync ()
     {
-        const int page_size = 25;
-        int max_parallelism = Math.Max(1, Math.Min(Environment.ProcessorCount, 2));
+        var rebuild_settings = _throttleSettings.Rebuild ?? PopulateCdcThrottleSettings.CreateDefaults().Rebuild;
+        int page_size = rebuild_settings.PageSize;
+        int max_parallelism = rebuild_settings.MaxParallelism;
+        int bulk_doc_chunk_size = rebuild_settings.BulkDocChunkSize;
+        int batch_delay_ms = rebuild_settings.BatchDelayMs;
+        int bulk_write_retry_count = rebuild_settings.BulkWriteRetryCount;
+        int bulk_write_retry_delay_ms = rebuild_settings.BulkWriteRetryDelayMs;
         int processed_case_count = 0;
         int document_error_count = 0;
         int de_id_bulk_error_count = 0;
@@ -324,7 +408,7 @@ public sealed class Report_PowerBI_Index_Struct
         int total_case_document_count = 0;
         c_document_sync_rebuild_context rebuild_context = null;
 
-        System.Console.WriteLine($"[PopulateCDC] CDC rebuild settings: page size {page_size}, max parallelism {max_parallelism}.");
+        System.Console.WriteLine($"[PopulateCDC] CDC rebuild throttling: {rebuild_settings.ToLogString()}.");
         ReportProgress("Phase 2 of 2: preparing CDC de-identified case database/report database rebuild from the CDC case database.");
 
         try
@@ -535,8 +619,18 @@ public sealed class Report_PowerBI_Index_Struct
                 build_stopwatch.Stop();
 
                 var write_stopwatch = Stopwatch.StartNew();
-                var de_id_write_result = await bulk_write_async("de_id", de_id_documents.ToList());
-                var report_write_result = await bulk_write_async("report", report_documents.ToList());
+                var de_id_write_result = await bulk_write_async(
+                    "de_id",
+                    de_id_documents.ToList(),
+                    bulk_doc_chunk_size,
+                    bulk_write_retry_count,
+                    bulk_write_retry_delay_ms);
+                var report_write_result = await bulk_write_async(
+                    "report",
+                    report_documents.ToList(),
+                    bulk_doc_chunk_size,
+                    bulk_write_retry_count,
+                    bulk_write_retry_delay_ms);
                 write_stopwatch.Stop();
 
                 processed_case_count += rows.Count;
@@ -553,6 +647,11 @@ public sealed class Report_PowerBI_Index_Struct
                     $"Phase 2 of 2: processed {processed_case_count} of {total_case_document_count} CDC case documents so far. " +
                     $"Generated {total_de_id_doc_count} de-identified case documents and {total_report_doc_count} report documents. " +
                     $"Build errors: {document_error_count}. de-identified case database bulk errors: {de_id_bulk_error_count}. report database bulk errors: {report_bulk_error_count}.");
+
+                if(batch_delay_ms > 0 && processed_case_count < total_case_document_count)
+                {
+                    await Task.Delay(batch_delay_ms);
+                }
             }
             catch (Exception ex)
             {

--- a/nccdphp-drh-mmria-services/mmria.services/Program.cs
+++ b/nccdphp-drh-mmria-services/mmria.services/Program.cs
@@ -160,9 +160,16 @@ public sealed class Program
 
         var actorSystem = ActorSystem.Create("mmria-actor-system").UseServiceProvider(provider);
         var couchDbHttpClient = provider.GetRequiredService<mmria.common.getset.CouchDbHttpClient>();
+        var populateCdcThrottleSettings = mmria.services.populate_cdc_instance.PopulateCdcThrottleSettingsLoader.Load(configuration);
+        Console.WriteLine($"[PopulateCDC] Copy throttling settings: {populateCdcThrottleSettings.Copy.ToLogString()}.");
+        Console.WriteLine($"[PopulateCDC] Rebuild throttling settings: {populateCdcThrottleSettings.Rebuild.ToLogString()}.");
         actorSystem.ActorOf(Akka.Actor.Props.Create<RecordsProcessor_Worker.Actors.BatchSupervisor>(couchDbHttpClient), "batch-supervisor");
         actorSystem.ActorOf(Akka.Actor.Props.Create<mmria.services.backup.BackupSupervisor>(couchDbHttpClient), "backup-supervisor");
-        actorSystem.ActorOf(Akka.Actor.Props.Create<mmria.services.populate_cdc_instance.PopulateCDCInstanceSupervisor>(couchDbHttpClient), "populate-cdc-instance-supervisor");
+        actorSystem.ActorOf(
+            Akka.Actor.Props.Create<mmria.services.populate_cdc_instance.PopulateCDCInstanceSupervisor>(
+                couchDbHttpClient,
+                populateCdcThrottleSettings),
+            "populate-cdc-instance-supervisor");
         
         builder.Services.AddHostedService<Worker>();
         builder.Services.AddSingleton(typeof(ActorSystem), (serviceProvider) => actorSystem);

--- a/nccdphp-drh-mmria-services/mmria.services/appsettings.json
+++ b/nccdphp-drh-mmria-services/mmria.services/appsettings.json
@@ -25,6 +25,18 @@
     "vitals_service_key": null,
     "config_id": "mmria-services",
     "cron_schedule": "0 */1 * * * ?",
+    "populate_cdc_copy_page_size": 10,
+    "populate_cdc_copy_max_parallelism": 1,
+    "populate_cdc_copy_bulk_doc_chunk_size": 20,
+    "populate_cdc_copy_batch_delay_ms": 250,
+    "populate_cdc_copy_bulk_write_retry_count": 3,
+    "populate_cdc_copy_bulk_write_retry_delay_ms": 1500,
+    "populate_cdc_rebuild_page_size": 10,
+    "populate_cdc_rebuild_max_parallelism": 1,
+    "populate_cdc_rebuild_bulk_doc_chunk_size": 20,
+    "populate_cdc_rebuild_batch_delay_ms": 250,
+    "populate_cdc_rebuild_bulk_write_retry_count": 3,
+    "populate_cdc_rebuild_bulk_write_retry_delay_ms": 1500,
     "metadata_version": "25.08.14"
   }
 }

--- a/source-code/mmria/mmria-server.tests/Tests/PopulateCDCInstanceTests.cs
+++ b/source-code/mmria/mmria-server.tests/Tests/PopulateCDCInstanceTests.cs
@@ -5,12 +5,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using mmria.common.SharedLibraries.MMRIAServices.DAL;
 using mmria.common.SharedLibraries.MMRIAServices.Helper;
 using mmria.common.SharedLibraries.MMRIAServices.Manager;
+using mmria.common.SharedLibraries.MMRIAServices.Model;
 using mmria_server.tests.Helpers;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -637,6 +640,174 @@ public sealed class PopulateCDCInstanceBatchingTests
         Assert.That(docs.All(doc => doc?["checked_out_by_tab_id"] == null), Is.True);
     }
 
+    [Test]
+    [Category("PopulateCDC")]
+    public async Task Scenario_F_PopulateCdc_AppliesConfiguredPageSize_Chunking_Retry_And_BatchDelay()
+    {
+        var credentials = LoadConfiguredCredentials();
+        int exportListGetCount = 0;
+        int targetBulkWriteCount = 0;
+        int transientBulkFailureCount = 0;
+        var sourceBatchSizes = new List<int>();
+        var sourceDocuments = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["case-1"] = @"{
+                ""_id"": ""case-1"",
+                ""first_name"": ""Alice"",
+                ""last_name"": ""Smith"",
+                ""created_by"": ""tester"",
+                ""last_updated_by"": ""tester""
+            }",
+            ["case-2"] = @"{
+                ""_id"": ""case-2"",
+                ""first_name"": ""Bea"",
+                ""last_name"": ""Jones"",
+                ""created_by"": ""tester"",
+                ""last_updated_by"": ""tester""
+            }",
+            ["case-3"] = @"{
+                ""_id"": ""case-3"",
+                ""first_name"": ""Cara"",
+                ""last_name"": ""Brown"",
+                ""created_by"": ""tester"",
+                ""last_updated_by"": ""tester""
+            }"
+        };
+
+        var handler = new RecordingHttpMessageHandler(async request =>
+        {
+            string url = request.RequestUri!.ToString();
+            string method = request.Method.Method.ToUpperInvariant();
+            string body = request.Content == null ? string.Empty : await request.Content.ReadAsStringAsync();
+
+            if (method == "GET" && url == "https://tenant1.example/tenant1_mmrds/_design/sortable/_view/by_date_created?skip=0&take=250000")
+            {
+                return CreateJsonResponse(@"{
+                    ""offset"": 0,
+                    ""rows"": [
+                        { ""id"": ""case-1"", ""key"": ""case-1"", ""value"": {} },
+                        { ""id"": ""case-2"", ""key"": ""case-2"", ""value"": {} },
+                        { ""id"": ""case-3"", ""key"": ""case-3"", ""value"": {} }
+                    ],
+                    ""total_rows"": 3
+                }");
+            }
+
+            if (method == "POST" && url == "https://tenant1.example/tenant1_mmrds/_all_docs?include_docs=true")
+            {
+                var requestJson = JObject.Parse(body);
+                var requestedKeys = requestJson["keys"]?.Values<string>().ToList() ?? [];
+                sourceBatchSizes.Add(requestedKeys.Count);
+
+                var rows = new JArray();
+                foreach (var key in requestedKeys)
+                {
+                    rows.Add(new JObject
+                    {
+                        ["id"] = key,
+                        ["key"] = key,
+                        ["doc"] = JObject.Parse(sourceDocuments[key])
+                    });
+                }
+
+                return CreateJsonResponse(new JObject
+                {
+                    ["offset"] = null,
+                    ["rows"] = rows,
+                    ["total_rows"] = rows.Count
+                }.ToString());
+            }
+
+            if (method == "GET" && url == "https://cdc.example/metadata/de-identified-export-list")
+            {
+                exportListGetCount++;
+                return CreateJsonResponse(@"{
+                    ""name_path_list"": {
+                        ""global"": [""first_name"", ""last_name""],
+                        ""tenant1"": [""first_name"", ""last_name""]
+                    }
+                }");
+            }
+
+            if (method == "POST" && url == "https://cdc.example/mmrds/_bulk_docs")
+            {
+                targetBulkWriteCount++;
+                if (transientBulkFailureCount == 0)
+                {
+                    transientBulkFailureCount++;
+                    throw new HttpRequestException("Transient bulk write failure");
+                }
+
+                var payload = JObject.Parse(body);
+                var docs = payload["docs"]?.OfType<JObject>().ToList() ?? [];
+                var responseDocs = new JArray();
+                foreach (var doc in docs)
+                {
+                    responseDocs.Add(new JObject
+                    {
+                        ["ok"] = true,
+                        ["id"] = doc.Value<string>("_id"),
+                        ["rev"] = "1-a"
+                    });
+                }
+
+                return CreateJsonResponse(responseDocs.ToString());
+            }
+
+            if (url.StartsWith("https://cdc.example/", StringComparison.OrdinalIgnoreCase))
+            {
+                return CreateJsonResponse(@"{ ""ok"": true }");
+            }
+
+            throw new InvalidOperationException($"Unexpected request during Populate CDC throttling test: {method} {url}");
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var couchDbClient = new mmria.common.getset.CouchDbHttpClient(new FixedHttpClientFactory(httpClient));
+        var manager = new MMRIAServicesManager(new MMRIAServicesDAL(couchDbClient), couchDbClient);
+        var throttleSettings = new PopulateCdcThrottleSettings
+        {
+            Copy = new PopulateCdcPhaseThrottleSettings
+            {
+                PageSize = 2,
+                MaxParallelism = 1,
+                BulkDocChunkSize = 1,
+                BatchDelayMs = 40,
+                BulkWriteRetryCount = 1,
+                BulkWriteRetryDelayMs = 0
+            },
+            Rebuild = PopulateCdcThrottleSettings.CreateDefaults().Rebuild
+        };
+
+        var configSet = new mmria.common.couchdb.ConfigurationSet();
+        configSet.name_value["metadata_version"] = "26.01.20";
+        configSet.detail_list["cdc"] = new mmria.common.couchdb.DBConfigurationDetail
+        {
+            url = "https://cdc.example",
+            user_name = credentials.SampleCredentials.StubDbUserName,
+            user_value = credentials.SampleCredentials.StubDbPassword
+        };
+        configSet.detail_list["tenant1"] = new mmria.common.couchdb.DBConfigurationDetail
+        {
+            url = "https://tenant1.example",
+            prefix = "tenant1",
+            user_name = credentials.SampleCredentials.StubDbUserName,
+            user_value = credentials.SampleCredentials.StubDbPassword
+        };
+
+        var message = BuildPopulateCdcMessage("tenant1");
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var (name, _) = await manager.PopulateCDCInstanceManger(message, configSet, throttleSettings: throttleSettings);
+        stopwatch.Stop();
+
+        Assert.That(name, Is.EqualTo("Finished"));
+        Assert.That(exportListGetCount, Is.EqualTo(1));
+        Assert.That(sourceBatchSizes, Is.EqualTo(new[] { 2, 1 }), "Copy page size should split source reads into two batches.");
+        Assert.That(targetBulkWriteCount, Is.EqualTo(4), "Chunked writes should retry the first failed chunk and then write each of the three chunks.");
+        Assert.That(transientBulkFailureCount, Is.EqualTo(1), "Exactly one transient bulk write failure should be retried.");
+        Assert.That(stopwatch.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(30), "Copy batch delay should add a measurable pause between source batches.");
+    }
+
     private static mmria.common.metadata.Populate_CDC_Instance BuildPopulateCdcMessage(params string[] includedPrefixes)
     {
         var includeSet = includedPrefixes?.Length > 0
@@ -654,6 +825,202 @@ public sealed class PopulateCDCInstanceBatchingTests
                 new mmria.common.metadata.State_List_Item { is_included = includeSet?.Contains("tenant5") ?? true, prefix = "tenant5", name = "tenant 5 test site" }
             ]
         };
+    }
+
+    private static HttpResponseMessage CreateJsonResponse(string json)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class FixedHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpClient _client;
+
+        public FixedHttpClientFactory(HttpClient client)
+        {
+            _client = client;
+        }
+
+        public HttpClient CreateClient(string name)
+        {
+            return _client;
+        }
+    }
+
+    private sealed class RecordingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, Task<HttpResponseMessage>> _responder;
+
+        public RecordingHttpMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder)
+        {
+            _responder = responder;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return _responder(request);
+        }
+    }
+}
+
+[TestFixture]
+public sealed class PopulateCdcThrottleSettingsLoaderTests
+{
+    [Test]
+    [Category("PopulateCDC")]
+    public void Load_UsesDefaults_WhenValuesAreMissing()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        var settings = mmria.services.populate_cdc_instance.PopulateCdcThrottleSettingsLoader.Load(configuration);
+        var defaults = PopulateCdcThrottleSettings.CreateDefaults();
+
+        Assert.That(settings.Copy.PageSize, Is.EqualTo(defaults.Copy.PageSize));
+        Assert.That(settings.Copy.MaxParallelism, Is.EqualTo(defaults.Copy.MaxParallelism));
+        Assert.That(settings.Copy.BulkDocChunkSize, Is.EqualTo(defaults.Copy.BulkDocChunkSize));
+        Assert.That(settings.Copy.BatchDelayMs, Is.EqualTo(defaults.Copy.BatchDelayMs));
+        Assert.That(settings.Copy.BulkWriteRetryCount, Is.EqualTo(defaults.Copy.BulkWriteRetryCount));
+        Assert.That(settings.Copy.BulkWriteRetryDelayMs, Is.EqualTo(defaults.Copy.BulkWriteRetryDelayMs));
+        Assert.That(settings.Rebuild.PageSize, Is.EqualTo(defaults.Rebuild.PageSize));
+        Assert.That(settings.Rebuild.MaxParallelism, Is.EqualTo(defaults.Rebuild.MaxParallelism));
+        Assert.That(settings.Rebuild.BulkDocChunkSize, Is.EqualTo(defaults.Rebuild.BulkDocChunkSize));
+        Assert.That(settings.Rebuild.BatchDelayMs, Is.EqualTo(defaults.Rebuild.BatchDelayMs));
+        Assert.That(settings.Rebuild.BulkWriteRetryCount, Is.EqualTo(defaults.Rebuild.BulkWriteRetryCount));
+        Assert.That(settings.Rebuild.BulkWriteRetryDelayMs, Is.EqualTo(defaults.Rebuild.BulkWriteRetryDelayMs));
+    }
+
+    [Test]
+    [Category("PopulateCDC")]
+    public void Load_ClampsInvalidValues_ToSafeMinimums()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["mmria_settings:populate_cdc_copy_page_size"] = "0",
+                ["mmria_settings:populate_cdc_copy_max_parallelism"] = "-1",
+                ["mmria_settings:populate_cdc_copy_bulk_doc_chunk_size"] = "-3",
+                ["mmria_settings:populate_cdc_copy_batch_delay_ms"] = "-10",
+                ["mmria_settings:populate_cdc_copy_bulk_write_retry_count"] = "-5",
+                ["mmria_settings:populate_cdc_copy_bulk_write_retry_delay_ms"] = "-15",
+                ["mmria_settings:populate_cdc_rebuild_page_size"] = "abc",
+                ["mmria_settings:populate_cdc_rebuild_max_parallelism"] = "0",
+                ["mmria_settings:populate_cdc_rebuild_bulk_doc_chunk_size"] = "-8",
+                ["mmria_settings:populate_cdc_rebuild_batch_delay_ms"] = "-30",
+                ["mmria_settings:populate_cdc_rebuild_bulk_write_retry_count"] = "-2",
+                ["mmria_settings:populate_cdc_rebuild_bulk_write_retry_delay_ms"] = "-40"
+            })
+            .Build();
+
+        var settings = mmria.services.populate_cdc_instance.PopulateCdcThrottleSettingsLoader.Load(configuration);
+        var defaults = PopulateCdcThrottleSettings.CreateDefaults();
+
+        Assert.That(settings.Copy.PageSize, Is.EqualTo(1));
+        Assert.That(settings.Copy.MaxParallelism, Is.EqualTo(1));
+        Assert.That(settings.Copy.BulkDocChunkSize, Is.EqualTo(0));
+        Assert.That(settings.Copy.BatchDelayMs, Is.EqualTo(0));
+        Assert.That(settings.Copy.BulkWriteRetryCount, Is.EqualTo(0));
+        Assert.That(settings.Copy.BulkWriteRetryDelayMs, Is.EqualTo(0));
+        Assert.That(settings.Rebuild.PageSize, Is.EqualTo(defaults.Rebuild.PageSize));
+        Assert.That(settings.Rebuild.MaxParallelism, Is.EqualTo(1));
+        Assert.That(settings.Rebuild.BulkDocChunkSize, Is.EqualTo(0));
+        Assert.That(settings.Rebuild.BatchDelayMs, Is.EqualTo(0));
+        Assert.That(settings.Rebuild.BulkWriteRetryCount, Is.EqualTo(0));
+        Assert.That(settings.Rebuild.BulkWriteRetryDelayMs, Is.EqualTo(0));
+    }
+}
+
+[TestFixture]
+public sealed class PopulateCdcRebuildBulkWriteTests
+{
+    [Test]
+    [Category("PopulateCDC")]
+    public async Task BulkWriteAsync_UsesChunking_And_RetriesTransientFailures()
+    {
+        int bulkWriteCallCount = 0;
+        int transientFailureCount = 0;
+        var handler = new RecordingHttpMessageHandler(async request =>
+        {
+            string url = request.RequestUri!.ToString();
+            string method = request.Method.Method.ToUpperInvariant();
+            string body = request.Content == null ? string.Empty : await request.Content.ReadAsStringAsync();
+
+            if (method == "POST" && url == "https://cdc.example/report/_bulk_docs")
+            {
+                bulkWriteCallCount++;
+                if (transientFailureCount == 0)
+                {
+                    transientFailureCount++;
+                    throw new HttpRequestException("Transient report bulk write failure");
+                }
+
+                var payload = JObject.Parse(body);
+                var docs = payload["docs"]?.OfType<JObject>().ToList() ?? [];
+                var responseDocs = new JArray();
+                foreach (var doc in docs)
+                {
+                    responseDocs.Add(new JObject
+                    {
+                        ["ok"] = true,
+                        ["id"] = doc.Value<string>("_id"),
+                        ["rev"] = "1-a"
+                    });
+                }
+
+                return CreateJsonResponse(responseDocs.ToString());
+            }
+
+            throw new InvalidOperationException($"Unexpected request during Populate CDC rebuild bulk write test: {method} {url}");
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var couchDbClient = new mmria.common.getset.CouchDbHttpClient(new FixedHttpClientFactory(httpClient));
+        var rebuild = new mmria.server.utils.c_document_sync_all(
+            new mmria.common.couchdb.DBConfigurationDetail
+            {
+                url = "https://cdc.example",
+                prefix = string.Empty,
+                user_name = "stub-user",
+                user_value = "stub-password"
+            },
+            "26.01.20",
+            couchDbClient);
+
+        var method = typeof(mmria.server.utils.c_document_sync_all).GetMethod(
+            "bulk_write_async",
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            types: new[] { typeof(string), typeof(List<string>), typeof(int), typeof(int), typeof(int) },
+            modifiers: null);
+
+        Assert.That(method, Is.Not.Null, "Expected private bulk_write_async overload to exist for phase 2 throttling.");
+
+        var task = (Task<(int success_count, int error_count)>)method!.Invoke(
+            rebuild,
+            new object[]
+            {
+                "report",
+                new List<string>
+                {
+                    @"{ ""_id"": ""doc-1"", ""value"": 1 }",
+                    @"{ ""_id"": ""doc-2"", ""value"": 2 }",
+                    @"{ ""_id"": ""doc-3"", ""value"": 3 }"
+                },
+                2,
+                1,
+                0
+            })!;
+
+        var result = await task;
+
+        Assert.That(result.success_count, Is.EqualTo(3));
+        Assert.That(result.error_count, Is.EqualTo(0));
+        Assert.That(transientFailureCount, Is.EqualTo(1));
+        Assert.That(bulkWriteCallCount, Is.EqualTo(3), "One transient retry plus two successful chunks should result in three bulk write attempts.");
     }
 
     private static HttpResponseMessage CreateJsonResponse(string json)


### PR DESCRIPTION
- Introduced `PopulateCdcThrottleSettings` and `PopulateCdcPhaseThrottleSettings` classes to manage throttling configurations for CDC population and rebuild processes.
- Updated `MMRIAServicesManager` to accept and utilize throttling settings during CDC instance population.
- Modified `PopulateCDCInstance` and `PopulateCDCInstanceSupervisor` actors to pass throttling settings.
- Enhanced bulk write operations to respect throttling settings, including page size, parallelism, chunk size, batch delays, and retry logic.
- Added configuration loading for throttling settings from `appsettings.json`.
- Implemented tests to validate throttling behavior, including chunking, retries, and delays.