### PR TITLE
Security scan fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ nccdphp-drh-mmria-services/mmria.services.tests/test-results.txt
 build_output.txt
 artifacts/
 docs/ai/logs/mmria-security-scan.csv
+docs/ai/logs/mmria-security-scan-2.csv

--- a/docs/ai/AI_CONTEXT.md
+++ b/docs/ai/AI_CONTEXT.md
@@ -4,7 +4,7 @@
 - Scope: Repo-wide rules, current architecture notes, and document routing for AI-assisted work in this repository.
 - When to use: Read this file first before planning or making changes, then jump to the feature-specific doc that matches the task.
 - Last verified: 2026-03-29
-- Related docs: [Refactor Risk Review Context](./refactor_risk_review_context.md), [Authentication, Session, and Timeout Context](./authentication_session_timeout.md), [Offline Mode Documentation](./offline_mode.md), [Case Summary Rendering Context](./case_summary_rendering_context.md), [Controller to SharedLibraries Migration Matrix](./controller_sharedlibraries_migration_matrix.md), [Historical Notes](./archive/)
+- Related docs: [Refactor Risk Review Context](./refactor_risk_review_context.md), [Authentication, Session, and Timeout Context](./authentication_session_timeout.md), [Offline Mode Documentation](./offline_mode.md), [Case Summary Rendering Context](./case_summary_rendering_context.md), [Controller to SharedLibraries Migration Matrix](./controller_sharedlibraries_migration_matrix.md), [Security Scan Remediation Tracker](./security_scan_remediation_tracker.md), [Fortify Scan Scope Exclusions](./fortify_scan_scope_exclusions.txt), [Historical Notes](./archive/)
 
 ## How to use this pack
 
@@ -126,7 +126,7 @@ Task routing
 | CVS integration | [CVS Community Vital Signs Context](./CVS_Community_Vital_Signs_Context.md) | External data enrichment guidance. |
 | Strongly typed case model generation | [Strongly Typed Case Generator Workflow](./strongly_typed_case_generator.md) | References an external utility repo; read the external dependency notes first. |
 | Sensitive-data scan guidance | [Security Scan Sensitive Data Heap Guidance](./security_scan_sensitive_data_heap_guidance.md) | Use when addressing heap or sensitive-data findings. |
-| Security scan tracker | [Security Scan Remediation Tracker](./security_scan_remediation_tracker.md) | Active working tracker for the current Fortify remediation batches and rescan notes. |
+| Security scan tracker | [Security Scan Remediation Tracker](./security_scan_remediation_tracker.md) | Active working tracker for the current Fortify remediation batches and rescan notes. Use it together with [Fortify Scan Scope Exclusions](./fortify_scan_scope_exclusions.txt) when rerunning the latest scan series. |
 
 
 ## Quick refactor checklist

--- a/docs/ai/fortify_scan_scope_exclusions.txt
+++ b/docs/ai/fortify_scan_scope_exclusions.txt
@@ -1,0 +1,1 @@
+nccdphp-drh-mmria-common/mmria.common/Testing/IJEGeneration/**

--- a/docs/ai/security_scan_remediation_tracker.md
+++ b/docs/ai/security_scan_remediation_tracker.md
@@ -1,115 +1,122 @@
 # Security Scan Remediation Tracker
 
 - Status: Active
-- Scope: Working tracker for the Fortify remediation effort driven by `docs/ai/logs/mmria-security-scan.csv`.
+- Scope: Working tracker for the Fortify remediation effort driven by `docs/ai/logs/mmria-security-scan-2.csv`.
 - When to use: Update this file before starting a remediation batch, after verification, and after every fresh scan export.
 - Last verified: 2026-03-29
-- Related docs: [AI Context Index](./AI_CONTEXT.md), [Security Scan Sensitive Data Heap Guidance](./security_scan_sensitive_data_heap_guidance.md)
+- Related docs: [AI Context Index](./AI_CONTEXT.md), [Security Scan Sensitive Data Heap Guidance](./security_scan_sensitive_data_heap_guidance.md), [Fortify Scan Scope Exclusions](./fortify_scan_scope_exclusions.txt)
 
-This document is the source of truth for the current security scan cleanup. It tracks what is in scope, how findings are grouped into batches, what changed in code, and what still needs either a rescan or a formal justification.
+This document is the source of truth for the current Fortify cleanup. It now tracks the latest scan export, the repo changes made after that export, and the remaining trace-review queue.
 
 ## Scan Source
 
-- Source file: [`docs/ai/logs/mmria-security-scan.csv`](./logs/mmria-security-scan.csv)
+- Source file: [`docs/ai/logs/mmria-security-scan-2.csv`](./logs/mmria-security-scan-2.csv)
 - Scan date in workspace: `2026-03-29`
 - Explicit exclusions:
   - rows tagged `False Positive`
   - any finding under `mmria-server.tests`
+- Future scan handling:
+  - save each rescan as a new file such as `docs/ai/logs/mmria-security-scan-3.csv`
+  - do not append new exports into an existing CSV
 
 ## Current Summary
 
-- Included findings after exclusions: `61`
-- Critical: `31`
-- High: `27`
-- Medium: `3`
-- Distinct category/file/line groups: `34`
+- Included findings after exclusions: `23`
+- Critical: `5`
+- High: `17`
+- Medium: `1`
+- Distinct category/file/line groups: `16`
+- No truly new category/file groups appeared in `mmria-security-scan-2.csv`; the remaining work is residual cleanup from the prior remediation pass.
+
+## Resolved Since Prior Scan
+
+These category/file groups were present in the prior baseline and are no longer present in `mmria-security-scan-2.csv`:
+
+- `Critical | Cross-Site Scripting: DOM | source-code/mmria/mmria-server/wwwroot/scripts/committee-member/index.js`
+- `Critical | Cross-Site Scripting: DOM | source-code/mmria/mmria-server/wwwroot/scripts/manage-case-folders/jurisdiction_renderer.js`
+- `Critical | Privacy Violation | nccdphp-drh-mmria-common/mmria.common/SharedLibraries/Account/DAL/AccountDAL.cs`
+- `High | Dynamic Code Evaluation: Code Injection | source-code/mmria/mmria-server/wwwroot/scripts/editor/page_renderer/list.js`
+- `High | Header Manipulation | nccdphp-drh-mmria-common/mmria.common/getset/CouchDbHttpClient.cs`
+- `High | Password Management: Hardcoded Password | source-code/mmria/mmria-server/appsettings.Development.https.json`
+- `High | Privacy Violation: Heap Inspection | nccdphp-drh-mmria-common/mmria.common/SharedLibraries/MMRIAServices/DAL/MMRIAServicesDAL.cs`
+- `High | Server-Side Request Forgery | nccdphp-drh-mmria-common/mmria.common/getset/CouchDbHttpClient.cs`
+- `High | Server-Side Request Forgery | source-code/mmria/mmria-server/model/actor/SteveAPI_Instance.cs`
+- `Medium | Header Manipulation: Cookies | source-code/mmria/mmria-server/wwwroot/scripts/duplicate/Duplicate.js`
 
 ## Batch Table
 
-| Batch | Status | Raw Rows | Distinct Groups | Primary Focus | Notes |
-| --- | --- | ---: | ---: | --- | --- |
-| 1 | `completed` | 7 | 2 | Scope cleanup and config secrets | Test-only IJE generator removed from production build; tracked dev cert password removed from checked-in HTTPS settings. |
-| 2 | `implemented, pending rescan` | 12 | 11 | Frontend DOM/eval/cookie hardening | Flagged `innerHTML` flows moved to sanitized DOM insertion, confirm callbacks switched to direct closures, duplicate-tab cookies removed. |
-| 3 | `implemented, pending rescan` | 11 | 10 | HTTP boundary hardening | STEVE URI/path handling hardened and flagged CouchDB header flows moved to typed request options. |
-| 4 | `implemented, pending rescan` | 24 | 4 | Auth and credential handling | Session/basic-auth handling consolidated and sensitive payload construction reduced. |
-| 5 | `pending rescan` | 7 | 7 | Heap-inspection re-triage | Revisit only after a fresh scan export. |
+| Batch | Status | Raw Rows | Primary Focus | Notes |
+| --- | --- | ---: | --- | --- |
+| 0 | `completed` | 23 | Tracker rebaseline | Tracker now points at `mmria-security-scan-2.csv` and future rescans are expected as new files. |
+| 1 | `implemented, pending Fortify rescan` | 6 | Scan scope exclusion for test-only IJE generation | Repo-tracked exclusion manifest added at `docs/ai/fortify_scan_scope_exclusions.txt`. |
+| 2 | `implemented, pending Fortify rescan` | 4 | Remaining frontend DOM findings | Remaining tainted dialog text is now written through DOM properties instead of parsed HTML; top-level case-folder insert now uses native DOM insertion. |
+| 3 | `implemented, pending Fortify rescan` | 5 | Remaining STEVE header/path findings | Bearer token validation and per-request auth helpers added; download directory, file, and zip paths now use explicit contained-path helpers. |
+| 4 | `pending trace review` | 8 | Residual heap-inspection findings | These should be actioned only with Fortify traces in hand. |
 
-## Batch Checklists
+## Active Batch Checklists
 
-### Batch 1: Scope Cleanup and Config Secrets
+### Batch 1: Scope Exclusion
 
 - [x] `High | Privacy Violation: Heap Inspection | nccdphp-drh-mmria-common/mmria.common/Testing/IJEGeneration/Generators/TestIJEFileGenerator.cs | line 1508 | rows 6`
-- [x] `High | Password Management: Hardcoded Password | source-code/mmria/mmria-server/appsettings.Development.https.json | line 17 | rows 1`
 - Working notes:
-  - `Testing/IJEGeneration/**` is only referenced from `mmria-server.tests`, so it was excluded from the production `mmria.common` build and compiled explicitly into the test project.
-  - `appsettings.Development.https.json` no longer carries the dev certificate password. Local development can continue to supply the same value from user secrets or `appsettings.local.json`.
+  - `Testing/IJEGeneration/**` remains compiled only into `mmria-server.tests`.
+  - The agreed Fortify exclusion path is stored in [`docs/ai/fortify_scan_scope_exclusions.txt`](./fortify_scan_scope_exclusions.txt).
+  - This batch is not closed until a fresh Fortify run confirms these rows are gone from the active results.
 
-### Batch 2: Frontend Injection Cleanup
+### Batch 2: Remaining Frontend DOM Findings
 
-- [x] `Critical | Cross-Site Scripting: DOM | source-code/mmria/mmria-server/wwwroot/scripts/committee-member/index.js | line 287 | rows 1`
-- [x] `Critical | Cross-Site Scripting: DOM | source-code/mmria/mmria-server/wwwroot/scripts/committee-member/index.js | line 330 | rows 1`
-- [x] `Critical | Cross-Site Scripting: DOM | source-code/mmria/mmria-server/wwwroot/scripts/committee-member/index.js | line 366 | rows 1`
-- [x] `Critical | Cross-Site Scripting: DOM | source-code/mmria/mmria-server/wwwroot/scripts/committee-member/index.js | line 409 | rows 1`
-- [x] `Medium | Header Manipulation: Cookies | source-code/mmria/mmria-server/wwwroot/scripts/duplicate/Duplicate.js | line 34 | rows 2`
-- [x] `High | Dynamic Code Evaluation: Code Injection | source-code/mmria/mmria-server/wwwroot/scripts/editor/page_renderer/list.js | line 2034 | rows 1`
 - [x] `Critical | Cross-Site Scripting: DOM | source-code/mmria/mmria-server/wwwroot/scripts/manage-case-folders/index.js | line 399 | rows 1`
-- [x] `Critical | Cross-Site Scripting: DOM | source-code/mmria/mmria-server/wwwroot/scripts/manage-case-folders/jurisdiction_renderer.js | line 216 | rows 1`
-- [x] `Critical | Cross-Site Scripting: DOM | source-code/mmria/mmria-server/wwwroot/scripts/mmria.js | line 1988 | rows 1`
-- [x] `Critical | Cross-Site Scripting: DOM | source-code/mmria/mmria-server/wwwroot/scripts/mmria.js | line 2072 | rows 1`
-- [x] `Critical | Cross-Site Scripting: DOM | source-code/mmria/mmria-server/wwwroot/scripts/mmria.js | line 2157 | rows 1`
+- [x] `Critical | Cross-Site Scripting: DOM | source-code/mmria/mmria-server/wwwroot/scripts/mmria.js | line 22 | rows 3`
 - Working notes:
-  - Shared DOM helpers now sanitize generated HTML before insertion and can accept direct `Node` content where needed.
-  - The flagged committee-member and manage-case-folders render paths now go through sanitized DOM insertion instead of raw `innerHTML`.
-  - The flagged confirm-dialog callback sites in `editor/page_renderer/list.js` now use direct closures instead of `new Function`.
-  - Duplicate-tab tracking no longer uses cookies; it now uses `sessionStorage` and `localStorage`.
+  - The `manage-case-folders` add-child flow no longer uses the flagged jQuery `.before(...)` sink for the top-level insert path.
+  - The remaining tainted dialog data in `mmria.js` now populates `textarea.value` and summary `textContent` after the dialog shell renders, so server response text no longer flows through `DOMParser.parseFromString(...)`.
+  - The shared sanitizer helper still exists for legacy generated markup; this batch specifically removes the currently flagged tainted flows into that helper.
 
-### Batch 3: HTTP Boundary Hardening
+### Batch 3: Remaining STEVE Transport Findings
 
-- [x] `High | Server-Side Request Forgery | nccdphp-drh-mmria-common/mmria.common/getset/CouchDbHttpClient.cs | line 57 | rows 1`
-- [x] `High | Header Manipulation | nccdphp-drh-mmria-common/mmria.common/getset/CouchDbHttpClient.cs | line 79 | rows 2`
-- [x] `High | Privacy Violation: Heap Inspection | nccdphp-drh-mmria-common/mmria.common/getset/CouchDbHttpClient.cs | line 327 | rows 1`
-- [x] `High | Header Manipulation | source-code/mmria/mmria-server/model/actor/SteveAPI_Instance.cs | line 69 | rows 1`
-- [x] `High | Server-Side Request Forgery | source-code/mmria/mmria-server/model/actor/SteveAPI_Instance.cs | line 205 | rows 1`
-- [x] `High | Header Manipulation | source-code/mmria/mmria-server/model/actor/SteveAPI_Instance.cs | line 206 | rows 1`
-- [x] `High | Header Manipulation | source-code/mmria/mmria-server/model/actor/SteveAPI_Instance.cs | line 217 | rows 1`
-- [x] `Medium | Path Manipulation: Base Path Overwriting | source-code/mmria/mmria-server/model/actor/SteveAPI_Instance.cs | line 233 | rows 1`
-- [x] `High | Server-Side Request Forgery | source-code/mmria/mmria-server/model/actor/SteveAPI_Instance.cs | line 248 | rows 1`
-- [x] `Critical | Path Manipulation | source-code/mmria/mmria-server/model/actor/SteveAPI_Instance.cs | line 264 | rows 1`
+- [x] `High | Header Manipulation | source-code/mmria/mmria-server/model/actor/SteveAPI_Instance.cs | line 75 | rows 1`
+- [x] `High | Header Manipulation | source-code/mmria/mmria-server/model/actor/SteveAPI_Instance.cs | line 215 | rows 1`
+- [x] `High | Header Manipulation | source-code/mmria/mmria-server/model/actor/SteveAPI_Instance.cs | line 226 | rows 1`
+- [x] `Critical | Path Manipulation | source-code/mmria/mmria-server/model/actor/SteveAPI_Instance.cs | line 272 | rows 1`
+- [x] `Medium | Path Manipulation: Base Path Overwriting | source-code/mmria/mmria-server/model/actor/SteveAPI_Instance.cs | line 394 | rows 1`
 - Working notes:
-  - `CouchDbHttpClient` now validates URIs centrally, applies auth/session/`If-Match`/service-key values through typed request options, and sanitizes remaining safe headers.
-  - STEVE integration now normalizes the base URI, uses typed bearer auth, escapes mailbox/message IDs, and constrains download/zip paths to the intended directory tree.
-  - Remaining `customHeaders` handling is retained only as a compatibility shim inside `CouchDbHttpClient`; the flagged internal callers were moved to typed request options.
+  - STEVE controllers now build a fresh internal `DownloadRequest` instead of mutating the inbound request object before sending it to the actor.
+  - `SteveAPI_Instance` now validates bearer token characters and length before any `Authorization` header assignment and routes GET/PATCH mailbox calls through a single request-builder helper.
+  - The actor now distinguishes trusted root directories from child directory/file names and resolves download folders, downloaded files, log files, and zip targets through explicit contained-path helpers.
 
-### Batch 4: Auth and Credential Handling
+### Batch 4: Residual Heap-Inspection Trace Review
 
-- [x] `Critical | Privacy Violation | nccdphp-drh-mmria-common/mmria.common/SharedLibraries/Account/DAL/AccountDAL.cs | line 156 | rows 7`
-- [x] `Critical | Privacy Violation | nccdphp-drh-mmria-common/mmria.common/SharedLibraries/Account/DAL/AccountDAL.cs | line 165 | rows 7`
-- [x] `Critical | Privacy Violation | nccdphp-drh-mmria-common/mmria.common/SharedLibraries/Account/DAL/AccountDAL.cs | line 166 | rows 7`
-- [x] `High | Privacy Violation: Heap Inspection | nccdphp-drh-mmria-common/mmria.common/SharedLibraries/MMRIAServices/DAL/MMRIAServicesDAL.cs | line 220 | rows 3`
-- Working notes:
-  - Session-auth form payload construction now writes directly into a single byte buffer and zeros sensitive buffers after use.
-  - Shared basic-auth creation now routes through `CouchDbHttpClient.CreateBasicAuthHeaderValue(...)` instead of ad hoc `username:password` base64 assembly.
-  - Service-key and `If-Match` flows touched during this batch were also moved onto typed request options to reduce header manipulation drift.
-
-### Batch 5: Residual Heap-Inspection Re-triage
-
+- [ ] `High | Privacy Violation: Heap Inspection | nccdphp-drh-mmria-common/mmria.common/getset/CouchDbHttpClient.cs | line 468 | rows 1`
 - [ ] `High | Privacy Violation: Heap Inspection | nccdphp-drh-mmria-common/mmria.common/SharedLibraries/Case/Manager/CaseManager.cs | line 1173 | rows 1`
 - [ ] `High | Privacy Violation: Heap Inspection | nccdphp-drh-mmria-common/mmria.common/SharedLibraries/MMRIAServices/Helper/MMRIAServicesHelper.cs | line 169 | rows 1`
-- [ ] `High | Privacy Violation: Heap Inspection | nccdphp-drh-mmria-common/mmria.common/SharedLibraries/OfflineCase/Manager/OfflineCaseManager.cs | line 76 | rows 1`
-- [ ] `High | Privacy Violation: Heap Inspection | nccdphp-drh-mmria-common/mmria.common/SharedLibraries/OfflineCase/Manager/OfflineCaseManager.cs | line 82 | rows 1`
-- [ ] `High | Privacy Violation: Heap Inspection | source-code/mmria/mmria-server/Controllers/AccountController.cs | line 443 | rows 1`
-- [ ] `High | Privacy Violation: Heap Inspection | source-code/mmria/mmria-server/Controllers/loggerController.cs | line 94 | rows 1`
+- [ ] `High | Privacy Violation: Heap Inspection | nccdphp-drh-mmria-common/mmria.common/SharedLibraries/OfflineCase/Manager/OfflineCaseManager.cs | line 73 | rows 1`
+- [ ] `High | Privacy Violation: Heap Inspection | nccdphp-drh-mmria-common/mmria.common/SharedLibraries/OfflineCase/Manager/OfflineCaseManager.cs | line 79 | rows 1`
+- [ ] `High | Privacy Violation: Heap Inspection | source-code/mmria/mmria-server/Controllers/AccountController.cs | line 422 | rows 1`
+- [ ] `High | Privacy Violation: Heap Inspection | source-code/mmria/mmria-server/Controllers/loggerController.cs | line 90 | rows 1`
 - [ ] `High | Privacy Violation: Heap Inspection | source-code/mmria/mmria-server/util/c_document_sync_all.cs | line 1049 | rows 1`
+- Working notes:
+  - Local code review suggests these are likely trace-review candidates rather than first-pass code fixes.
+  - Current likely classifications:
+    - `CouchDbHttpClient`: host normalization and SSRF guard state, likely scanner taint carryover.
+    - `CaseManager` and `OfflineCaseManager`: case/tab/session conflict identifiers used for lock-state decisions.
+    - `MMRIAServicesHelper` and `c_document_sync_all`: document `_id` and `_rev` cleanup/bookkeeping.
+    - `AccountController`: redirect target handling around offline key entry.
+    - `loggerController`: abbreviated session display strings for troubleshooting UI.
+  - Do not change these blindly. Each survivor must end as either code-fixed or trace-backed justified after the next scan.
 
 ## Rescan Results
 
 | Date | Scope | Result | Notes |
 | --- | --- | --- | --- |
-| 2026-03-29 | Baseline plan/import | `61` included findings after exclusions | Starting point captured from the current CSV export. |
-| 2026-03-29 | Code implementation verification | `dotnet build` passed for `mmria-server`; `mmria-server.tests` build passed with `--no-restore -m:1` | The default parallel test-project restore path intermittently failed without compiler errors, but single-node/no-restore verification succeeded after restore was warm. Fresh Fortify rescan still pending. |
+| 2026-03-29 | Prior baseline | `61` included findings after exclusions | Original remediation baseline from `mmria-security-scan.csv`. |
+| 2026-03-29 | Latest authoritative export | `23` included findings after exclusions | Rebaseline from `mmria-security-scan-2.csv`. |
+| 2026-03-29 | Post-rebaseline implementation | `pending Fortify rescan` | Batch 1 exclusion manifest, Batch 2 frontend fixes, and Batch 3 STEVE fixes are in repo but not yet validated by a fresh scan. |
 
-## Notes and Justification Queue
+## Verification Notes
 
-- Batch 5 should not be actioned from the baseline CSV alone. Several flagged sinks point at revision IDs, session-display strings, or redirect targets rather than obvious sensitive values.
-- Batch 2 through Batch 4 are implemented in code and build-verified, but they still need a fresh Fortify export before they should be considered closed.
-- If a finding survives after a fresh rescan, capture the Fortify trace, decide whether the issue is real, then either implement the narrow fix or record the approved justification here.
+- Build verification for the previous remediation pass remains valid, but a fresh build was not yet rerun after the latest follow-up changes captured in this tracker revision.
+- The next verification step should be:
+  - run `dotnet build` for `mmria-server`
+  - rerun the Fortify export with `docs/ai/fortify_scan_scope_exclusions.txt` applied
+  - record the next CSV as `docs/ai/logs/mmria-security-scan-3.csv`
+  - update this tracker with the post-rescan counts and any surviving findings

--- a/source-code/mmria/mmria-server/Controllers/steveMMRIAController.cs
+++ b/source-code/mmria/mmria-server/Controllers/steveMMRIAController.cs
@@ -166,18 +166,23 @@ public sealed class steveMMRIAController : Controller
             System.DateTime? result = null; 
 
             var steve_api = configuration.GetSteveAPIConfigurationDetail();
-
-            request.seaBucketKMSKey = steve_api.sea_bucket_kms_key;
-            request.clientName = steve_api.client_name;
-            request.clientSecretKey = steve_api.client_secret_key;
-            request.base_url = steve_api.base_url;
-            request.download_directory = download_directory;
-            request.file_name = GetFileName(request.Mailbox);
+            var safeRequest = new DownloadRequest
+            {
+                BeginDate = request.BeginDate,
+                EndDate = request.EndDate,
+                Mailbox = request.Mailbox,
+                seaBucketKMSKey = steve_api.sea_bucket_kms_key,
+                clientName = steve_api.client_name,
+                clientSecretKey = steve_api.client_secret_key,
+                base_url = steve_api.base_url,
+                download_directory = download_directory,
+                file_name = GetFileName(request.Mailbox)
+            };
 
             var processor = _actorSystem.ActorSelection("user/steve-api-supervisor");
 
             //result = (System.DateTime) await processor.Ask(request);
-            processor.Tell(request);
+            processor.Tell(safeRequest);
             
             //System.Console.WriteLine("here");
 

--- a/source-code/mmria/mmria-server/Controllers/stevePRAMSController.cs
+++ b/source-code/mmria/mmria-server/Controllers/stevePRAMSController.cs
@@ -165,18 +165,21 @@ public sealed class stevePRAMSController : Controller
             var processor = _actorSystem.ActorSelection("user/steve-api-supervisor");
 
             var steve_api = configuration.GetSteveAPIConfigurationDetail();
-
-            request.seaBucketKMSKey = steve_api.sea_bucket_kms_key;
-            request.clientName = steve_api.client_name;
-            request.clientSecretKey = steve_api.client_secret_key;
-            request.base_url = steve_api.base_url;
-
-            request.download_directory = download_directory;
-
-            request.file_name = GetFileName(request.Mailbox);
+            var safeRequest = new DownloadRequest
+            {
+                BeginDate = request.BeginDate,
+                EndDate = request.EndDate,
+                Mailbox = request.Mailbox,
+                seaBucketKMSKey = steve_api.sea_bucket_kms_key,
+                clientName = steve_api.client_name,
+                clientSecretKey = steve_api.client_secret_key,
+                base_url = steve_api.base_url,
+                download_directory = download_directory,
+                file_name = GetFileName(request.Mailbox)
+            };
 
             //result = (System.DateTime) await processor.Ask(request);
-            processor.Tell(request);
+            processor.Tell(safeRequest);
             
             //System.Console.WriteLine("here");
 

--- a/source-code/mmria/mmria-server/model/actor/SteveAPI_Instance.cs
+++ b/source-code/mmria/mmria-server/model/actor/SteveAPI_Instance.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Akka.Actor;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -30,6 +31,7 @@ public sealed class SteveAPI_Instance : ReceiveActor
     IConfiguration configuration;
     ILogger logger;
     private readonly HttpClient _httpClient;
+    private static readonly Regex SteveBearerTokenPattern = new("^[A-Za-z0-9._~+/=-]{1,4096}$", RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
     protected override void PreStart() => Console.WriteLine("Process_Message started");
     protected override void PostStop() => Console.WriteLine("Process_Message stopped");
@@ -70,17 +72,19 @@ public sealed class SteveAPI_Instance : ReceiveActor
                 throw new InvalidOperationException("STEVE authentication response did not include a bearer token.");
             }
 
+            var bearerToken = ValidateSteveBearerToken(auth_response.token);
+
             var list_mailboxes_url = BuildSteveUri(baseUri, "mailbox");
-            using var mailboxRequest = new HttpRequestMessage(HttpMethod.Get, list_mailboxes_url);
-            mailboxRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", auth_response.token);
+            using var mailboxRequest = CreateSteveRequest(HttpMethod.Get, list_mailboxes_url, bearerToken);
             using var mailboxResponse = await _httpClient.SendAsync(mailboxRequest);
             mailboxResponse.EnsureSuccessStatusCode();
             response = await mailboxResponse.Content.ReadAsStringAsync();
             System.Console.WriteLine(response);
 
-            var GetMailboxListResult = System.Text.Json.JsonSerializer.Deserialize<GetMailboxListResult>(response);            
-
-            var download_directory = ResolveContainedPath(message.download_directory, message.file_name);
+            var GetMailboxListResult = System.Text.Json.JsonSerializer.Deserialize<GetMailboxListResult>(response);
+            var downloadRootDirectory = NormalizeTrustedDirectoryRoot(message.download_directory, nameof(message.download_directory));
+            var downloadDirectoryName = ValidateContainedName(message.file_name, nameof(message.file_name));
+            var download_directory = ResolveContainedDirectoryPath(downloadRootDirectory, downloadDirectoryName);
 
             System.IO.Directory.CreateDirectory(download_directory);
 
@@ -92,7 +96,7 @@ public sealed class SteveAPI_Instance : ReceiveActor
                 {
                     var new_message = message with { Mailbox = item.Key };
 
-                    var mailbox_directory = System.IO.Path.Combine(download_directory, item.Value);
+                    var mailbox_directory = ResolveContainedDirectoryPath(download_directory, item.Value);
 
                     System.IO.Directory.CreateDirectory(mailbox_directory);
                     var one_mailbox_response = await OneMailBox
@@ -100,7 +104,7 @@ public sealed class SteveAPI_Instance : ReceiveActor
                         new_message,
                         GetMailboxListResult,
                         baseUri,
-                        auth_response.token,
+                        bearerToken,
                         mailbox_directory
                     );
 
@@ -116,7 +120,7 @@ public sealed class SteveAPI_Instance : ReceiveActor
                     message,
                     GetMailboxListResult,
                     baseUri,
-                    auth_response.token,
+                    bearerToken,
                     download_directory
                 );
 
@@ -124,23 +128,22 @@ public sealed class SteveAPI_Instance : ReceiveActor
                 OneMailBoxResult.ErrorList.AddRange(one_mailbox_response.ErrorList);
             }
 
-
+            var downloadLogPath = ResolveContainedFilePath(download_directory, "download-log.txt");
             System.IO.File.WriteAllText
             (
-                download_directory + "/download-log.txt", 
+                downloadLogPath,
                 $"STEVE Mailbox:{message.Mailbox}\nBeginDate:{ToRequestString(message.BeginDate)} => {ToBeginDateTimeRequestString(message.BeginDate)}\nEndDate:{ToRequestString(message.EndDate)} => {ToEndDateTimeRequestString(message.EndDate)}\nsuccess:{OneMailBoxResult.SuccessCount} errors:{OneMailBoxResult.ErrorList.Count} warnings:{OneMailBoxResult.WarningList.Count}\n\nErrors:\n{string.Join('\n', OneMailBoxResult.ErrorList)}\n\nWarnings:\n{string.Join('\n', OneMailBoxResult.WarningList)}"
             );
 
 
-            var zip_file_name = message.file_name + ".zip";
+            var zip_file_name = ValidateContainedName(message.file_name + ".zip", nameof(message.file_name));
             mmria.server.utils.cFolderCompressor folder_compressor = new mmria.server.utils.cFolderCompressor();
             string encryption_key = null;
 
             try
             {
 
-
-                var target_zip_file = ResolveContainedPath(message.download_directory, zip_file_name);
+                var target_zip_file = ResolveContainedFilePath(downloadRootDirectory, zip_file_name);
 
                 if(System.IO.File.Exists(target_zip_file))
                 {
@@ -177,7 +180,7 @@ public sealed class SteveAPI_Instance : ReceiveActor
         DownloadRequest message,
         GetMailboxListResult GetMailboxListResult,
         Uri baseUri,
-        string token,
+        string bearerToken,
         string download_directory
     )
     {
@@ -211,8 +214,7 @@ public sealed class SteveAPI_Instance : ReceiveActor
                 baseUri,
                 $"mailbox/{Uri.EscapeDataString(mail_box.mailboxId)}/all",
                 $"count=1000&fromDate={Uri.EscapeDataString(ToBeginDateTimeRequestString(message.BeginDate))}&toDate={Uri.EscapeDataString(ToEndDateTimeRequestString(message.EndDate))}");
-            using var unreadRequest = new HttpRequestMessage(HttpMethod.Get, mailbox_unread_url);
-            unreadRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            using var unreadRequest = CreateSteveRequest(HttpMethod.Get, mailbox_unread_url, bearerToken);
             using var unreadResponse = await _httpClient.SendAsync(unreadRequest);
             unreadResponse.EnsureSuccessStatusCode();
             var response = await unreadResponse.Content.ReadAsStringAsync();
@@ -220,29 +222,19 @@ public sealed class SteveAPI_Instance : ReceiveActor
             var UnreadMessageResult = System.Text.Json.JsonSerializer.Deserialize<MailBoxMessageResult>(response);
             if(UnreadMessageResult.messages?.Length > 0)
             {
-
                 using (var client = new System.Net.Http.HttpClient(){ Timeout = new TimeSpan(0,5, 0) })
                 {
-                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
                     foreach(var msg in UnreadMessageResult.messages)
                     {
                         var is_downloaded = false;
                         var message_id = msg.messageId;
                         var download_message_url = BuildSteveUri(baseUri, $"file/{Uri.EscapeDataString(message_id)}");
-                        
-                        // Sanitize filename to prevent path traversal attacks
-                        var safeFileName = System.IO.Path.GetFileName(msg.fileName);
-                        if (string.IsNullOrWhiteSpace(safeFileName))
-                        {
-                            result.ErrorList.Add($"Invalid filename from STEVE API: {msg.fileName}");
-                            continue;
-                        }
 
                         string message_path;
                         try
                         {
-                            message_path = ResolveContainedPath(download_directory, safeFileName);
+                            var safeFileName = ValidateContainedName(msg.fileName, nameof(msg.fileName));
+                            message_path = ResolveContainedFilePath(download_directory, safeFileName);
                         }
                         catch (ArgumentException)
                         {
@@ -252,8 +244,8 @@ public sealed class SteveAPI_Instance : ReceiveActor
 
                         try
                         {
-
-                            using (var client_response = await client.GetAsync(download_message_url))
+                            using var downloadRequest = CreateSteveRequest(HttpMethod.Get, download_message_url, bearerToken);
+                            using (var client_response = await client.SendAsync(downloadRequest, HttpCompletionOption.ResponseHeadersRead))
                             {
                                 /*
                                 using (var content = client_response.Content)
@@ -309,7 +301,8 @@ public sealed class SteveAPI_Instance : ReceiveActor
                             var mark_as_read_message_url = BuildSteveUri(baseUri, $"mailbox/{Uri.EscapeDataString(message_id)}");
                             try
                             {
-                                using (var client_response = await client.PatchAsync(mark_as_read_message_url, null))
+                                using var markAsReadRequest = CreateSteveRequest(HttpMethod.Patch, mark_as_read_message_url, bearerToken);
+                                using (var client_response = await client.SendAsync(markAsReadRequest))
                                 {
                                     client_response.EnsureSuccessStatusCode();
                                     var responseBody = await client_response.Content.ReadAsStringAsync();
@@ -358,6 +351,32 @@ public sealed class SteveAPI_Instance : ReceiveActor
         return normalizedUri.Uri;
     }
 
+    private static HttpRequestMessage CreateSteveRequest(HttpMethod method, Uri requestUri, string bearerToken)
+    {
+        var request = new HttpRequestMessage(method, requestUri);
+        request.Headers.Authorization = CreateBearerAuthHeader(bearerToken);
+        return request;
+    }
+
+    private static AuthenticationHeaderValue CreateBearerAuthHeader(string bearerToken) =>
+        new("Bearer", ValidateSteveBearerToken(bearerToken));
+
+    private static string ValidateSteveBearerToken(string bearerToken)
+    {
+        if (string.IsNullOrWhiteSpace(bearerToken))
+        {
+            throw new ArgumentException("STEVE bearer token is required.", nameof(bearerToken));
+        }
+
+        var trimmedToken = bearerToken.Trim();
+        if (!SteveBearerTokenPattern.IsMatch(trimmedToken))
+        {
+            throw new ArgumentException("STEVE bearer token contains unexpected characters.", nameof(bearerToken));
+        }
+
+        return trimmedToken;
+    }
+
     private static Uri BuildSteveUri(Uri baseUri, string relativePath, string query = null)
     {
         var targetUri = new Uri(baseUri, relativePath.TrimStart('/'));
@@ -377,28 +396,76 @@ public sealed class SteveAPI_Instance : ReceiveActor
         }.Uri;
     }
 
-    private static string ResolveContainedPath(string baseDirectory, string childName)
+    private static string NormalizeTrustedDirectoryRoot(string baseDirectory, string paramName)
     {
         if (string.IsNullOrWhiteSpace(baseDirectory))
         {
-            throw new ArgumentException("Base directory is required.", nameof(baseDirectory));
-        }
-
-        var safeChildName = System.IO.Path.GetFileName(childName);
-        if (string.IsNullOrWhiteSpace(safeChildName))
-        {
-            throw new ArgumentException("Child path must resolve to a file or directory name.", nameof(childName));
+            throw new ArgumentException("Base directory is required.", paramName);
         }
 
         var rootPath = System.IO.Path.GetFullPath(baseDirectory);
-        var combinedPath = System.IO.Path.GetFullPath(System.IO.Path.Combine(rootPath, safeChildName));
-        if (!combinedPath.StartsWith(rootPath + System.IO.Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) &&
-            !combinedPath.Equals(rootPath, StringComparison.OrdinalIgnoreCase))
+        if (!System.IO.Path.IsPathFullyQualified(rootPath))
         {
-            throw new ArgumentException("Resolved path escaped the configured base directory.", nameof(childName));
+            throw new ArgumentException("Base directory must be fully qualified.", paramName);
         }
 
+        return System.IO.Path.EndsInDirectorySeparator(rootPath)
+            ? rootPath
+            : rootPath + System.IO.Path.DirectorySeparatorChar;
+    }
+
+    private static string ResolveContainedDirectoryPath(string trustedBaseDirectory, string childDirectoryName)
+    {
+        var normalizedRoot = NormalizeTrustedDirectoryRoot(trustedBaseDirectory, nameof(trustedBaseDirectory));
+        var safeDirectoryName = ValidateContainedName(childDirectoryName, nameof(childDirectoryName));
+        var combinedPath = System.IO.Path.GetFullPath(System.IO.Path.Combine(normalizedRoot, safeDirectoryName));
+        EnsureContainedPath(normalizedRoot, combinedPath, nameof(childDirectoryName));
         return combinedPath;
+    }
+
+    private static string ResolveContainedFilePath(string trustedBaseDirectory, string fileName)
+    {
+        var normalizedRoot = NormalizeTrustedDirectoryRoot(trustedBaseDirectory, nameof(trustedBaseDirectory));
+        var safeFileName = ValidateContainedName(fileName, nameof(fileName));
+        var combinedPath = System.IO.Path.GetFullPath(System.IO.Path.Combine(normalizedRoot, safeFileName));
+        EnsureContainedPath(normalizedRoot, combinedPath, nameof(fileName));
+        return combinedPath;
+    }
+
+    private static string ValidateContainedName(string value, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("A non-empty path segment is required.", paramName);
+        }
+
+        var trimmedValue = value.Trim();
+        if (trimmedValue is "." or "..")
+        {
+            throw new ArgumentException("Relative path operators are not allowed.", paramName);
+        }
+
+        if (System.IO.Path.IsPathRooted(trimmedValue) ||
+            trimmedValue.Contains(System.IO.Path.DirectorySeparatorChar) ||
+            trimmedValue.Contains(System.IO.Path.AltDirectorySeparatorChar))
+        {
+            throw new ArgumentException("Only a single file or directory name is allowed.", paramName);
+        }
+
+        if (trimmedValue.IndexOfAny(System.IO.Path.GetInvalidFileNameChars()) >= 0)
+        {
+            throw new ArgumentException("Path segment contains invalid filename characters.", paramName);
+        }
+
+        return trimmedValue;
+    }
+
+    private static void EnsureContainedPath(string trustedBaseDirectory, string resolvedPath, string paramName)
+    {
+        if (!resolvedPath.StartsWith(trustedBaseDirectory, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException("Resolved path escaped the configured base directory.", paramName);
+        }
     }
 
     class OneMailBoxResult

--- a/source-code/mmria/mmria-server/wwwroot/scripts/manage-case-folders/index.js
+++ b/source-code/mmria/mmria-server/wwwroot/scripts/manage-case-folders/index.js
@@ -396,7 +396,11 @@ function jurisdiction_add_child_click(p_parent_id, p_name, p_user_id)
                 var x = render_new_case_folder(new_child, null, parseInt(y.dataset.nestedLevel));
                 if(y.dataset.nestedLevel == '0')
                 {
-                    $('#case_folder_break').before(x);
+                    var case_folder_break = document.getElementById('case_folder_break');
+                    if(case_folder_break && case_folder_break.parentNode)
+                    {
+                        case_folder_break.parentNode.insertBefore(x, case_folder_break);
+                    }
                 }
                 else
                 {

--- a/source-code/mmria/mmria-server/wwwroot/scripts/mmria.js
+++ b/source-code/mmria/mmria-server/wwwroot/scripts/mmria.js
@@ -83,6 +83,13 @@ var $mmria = function()
         return element;
     };
 
+    const formatServerResponseDetail = (error, note) => {
+        const status = error?.status === 0 ? "Unsent" : String(error?.status ?? '');
+        const action = note == null ? '' : String(note);
+        const responseText = error?.responseText == undefined ? "offline" : String(error.responseText);
+        return `Status: ${status}\nAction: ${action}\nServer Response:\n${responseText}`;
+    };
+
     return {
         escapeHtml: escapeHtml,
         create_sanitized_fragment: createSanitizedFragment,
@@ -2064,12 +2071,7 @@ Please update the duplicate record as applicable.
                          <a href="javascript:$mmria.server_response_detail_div_show()">Show Error Detail</a> | <a href="javascript:$mmria.server_response_detail_div_hide()">Hide Error Detail</a>
                          <div id="server_response_detail_div" style="display:none">
                          <br/>
-                         <textarea id=server_response_textarea rows=7 cols=55 readonly>
-Status: ${escapeHtml(p_error.status === 0 ? "Unsent" : String(p_error.status))}
-Action: ${escapeHtml(p_note)}
-Server Response:
-${escapeHtml(p_error.responseText== undefined ? "offline" : p_error.responseText)}
-                         </textarea>
+                         <textarea id="server_response_textarea" rows="7" cols="55" readonly></textarea>
                          <button id="unstable_network_copy_btn" class="btn btn-primary mr-1" style="font-family: 'Open-Sans';">Copy Details to Clipboard</button>
                          </div>
                         </div>
@@ -2083,6 +2085,12 @@ ${escapeHtml(p_error.responseText== undefined ? "offline" : p_error.responseText
                 `);
     
                 setSanitizedHtml(element, html.join(""));
+
+                const unstableNetworkTextarea = document.getElementById("server_response_textarea");
+                if (unstableNetworkTextarea != null)
+                {
+                    unstableNetworkTextarea.value = formatServerResponseDetail(p_error, p_note);
+                }
 
                 // Attach event listeners
                 document.getElementById("unstable_network_dialog_close_button").onclick = () => $mmria.unstable_network_dialog_click();
@@ -2141,7 +2149,7 @@ ${escapeHtml(p_error.responseText== undefined ? "offline" : p_error.responseText
                     <div id="mmria_dialog5" class="ui-dialog-content ui-widget-content">
                         <div class="modal-body">
                          <p>An error occured while saving.</p>
-                         <p>Error Summary: ${escapeHtml(p_note)}</p>
+                         <p id="save_error_500_summary"></p>
                          <p>1. Press "Save and Continue" and confirm that you see a green "Case information has been saved." message.</p>
                          <p>
                             2. If no confirmation message try navigating back to <b>MMRIA Home</b> and then to <b>View or Modify Data</b> and select your case again.<br/>
@@ -2150,12 +2158,7 @@ ${escapeHtml(p_error.responseText== undefined ? "offline" : p_error.responseText
                          </p>
                        
                          <br/>
-                         <textarea id=server_response_textarea2 rows=7 cols=55 readonly>
-Status: ${escapeHtml(p_error.status === 0 ? "Unsent" : String(p_error.status))}
-Action: ${escapeHtml(p_note)}
-Server Response:
-${escapeHtml(p_error.responseText== undefined ? "offline" : p_error.responseText)}
-                         </textarea>
+                         <textarea id="save_error_500_textarea" rows="7" cols="55" readonly></textarea>
                         </div>
 
                     </div>
@@ -2167,6 +2170,18 @@ ${escapeHtml(p_error.responseText== undefined ? "offline" : p_error.responseText
                 `);
     
                 setSanitizedHtml(element, html.join(""));
+
+                const saveErrorSummary = document.getElementById("save_error_500_summary");
+                if (saveErrorSummary != null)
+                {
+                    saveErrorSummary.textContent = `Error Summary: ${p_note ?? ''}`;
+                }
+
+                const saveErrorTextarea = document.getElementById("save_error_500_textarea");
+                if (saveErrorTextarea != null)
+                {
+                    saveErrorTextarea.value = formatServerResponseDetail(p_error, p_note);
+                }
 
                 // Attach event listener
                 document.getElementById("save_error_500_dialog_close_button").onclick = () => $mmria.save_error_500_dialog_click();
@@ -2229,18 +2244,13 @@ ${escapeHtml(p_error.responseText== undefined ? "offline" : p_error.responseText
                     <div id="mmria_dialog6" class="ui-dialog-content ui-widget-content">
                         <div class="modal-body">
                          <p>Unable to save field data</p><br/>
-                         <p>Error Summary: ${escapeHtml(p_note)}</p>
+                         <p id="field_save_error_summary"></p>
                          <br/>
                          If the problem persists, send an email to MMRIA Support  <a href="mailto:mmriasupport@cdc.gov">mmriasupport@cdc.gov</a>
                          </p>
                        
                          <br/>
-                         <textarea id=server_response_textarea2 rows=7 cols=55 readonly>
-Status: ${escapeHtml(p_error.status === 0 ? "Unsent" : String(p_error.status))}
-Action: ${escapeHtml(p_note)}
-Server Response:
-${escapeHtml(p_error.responseText== undefined ? "offline" : p_error.responseText)}
-                         </textarea>
+                         <textarea id="field_save_error_textarea" rows="7" cols="55" readonly></textarea>
                         </div>
 
                     </div>
@@ -2252,6 +2262,18 @@ ${escapeHtml(p_error.responseText== undefined ? "offline" : p_error.responseText
                 `);
     
                 setSanitizedHtml(element, html.join(""));
+
+                const fieldSaveErrorSummary = document.getElementById("field_save_error_summary");
+                if (fieldSaveErrorSummary != null)
+                {
+                    fieldSaveErrorSummary.textContent = `Error Summary: ${p_note ?? ''}`;
+                }
+
+                const fieldSaveErrorTextarea = document.getElementById("field_save_error_textarea");
+                if (fieldSaveErrorTextarea != null)
+                {
+                    fieldSaveErrorTextarea.value = formatServerResponseDetail(p_error, p_note);
+                }
 
                 // Attach event listener
                 document.getElementById("field_save_error_dialog_close_button").onclick = () => $mmria.field_save_error_dialog_click();


### PR DESCRIPTION
- Updated .gitignore to include new security scan log file.
- Revised AI_CONTEXT.md to add related documentation links for security scan remediation.
- Enhanced security_scan_remediation_tracker.md to reflect changes in scan results and remediation efforts, including new batch summaries and verification notes.
- Refactored steveMMRIAController and stevePRAMSController to use a new DownloadRequest object for better encapsulation of request parameters.
- Improved SteveAPI_Instance to validate bearer tokens and ensure safe directory and file path handling.
- Updated manage-case-folders and mmria scripts to enhance DOM manipulation and error handling.
- Created fortify_scan_scope_exclusions.txt to document exclusions for Fortify scans.