### PR TITLE
fix: preserve <br> tags in case narrative rich text editor

### DIFF
--- a/source-code/mmria/mmria-server/wwwroot/scripts/editor/page_renderer/textarea.js
+++ b/source-code/mmria/mmria-server/wwwroot/scripts/editor/page_renderer/textarea.js
@@ -197,7 +197,7 @@ function textarea_render(p_result, p_metadata, p_data, p_ui, p_metadata_path, p_
 
 function tbw_change_paste(p_object_path, p_metadata_path, p_dictionary_path)
 {
-    let data = $('#case_narrative_editor').closest('.trumbowyg-box').find('.trumbowyg-editor').html();
+    let data = $('#case_narrative_editor').trumbowyg('html');
 
     //g_textarea_oninput(p_object_path, p_metadata_path,p_dictionary_path, data);
     //return;
@@ -227,7 +227,7 @@ function tbw_change_paste(p_object_path, p_metadata_path, p_dictionary_path)
 
 function tbw_onchange(p_object_path, p_metadata_path, p_dictionary_path)
 {
-    let data = $('#case_narrative_editor').closest('.trumbowyg-box').find('.trumbowyg-editor').html();
+    let data = $('#case_narrative_editor').trumbowyg('html');
 
     //g_textarea_oninput(p_object_path, p_metadata_path,p_dictionary_path, data);
     //return;

--- a/source-code/mmria/mmria-server/wwwroot/scripts/editor/page_renderer/textarea.js
+++ b/source-code/mmria/mmria-server/wwwroot/scripts/editor/page_renderer/textarea.js
@@ -197,7 +197,7 @@ function textarea_render(p_result, p_metadata, p_data, p_ui, p_metadata_path, p_
 
 function tbw_change_paste(p_object_path, p_metadata_path, p_dictionary_path)
 {
-    let data = $('.trumbowyg-editor').html();
+    let data = $('#case_narrative_editor').closest('.trumbowyg-box').find('.trumbowyg-editor').html();
 
     //g_textarea_oninput(p_object_path, p_metadata_path,p_dictionary_path, data);
     //return;
@@ -227,7 +227,7 @@ function tbw_change_paste(p_object_path, p_metadata_path, p_dictionary_path)
 
 function tbw_onchange(p_object_path, p_metadata_path, p_dictionary_path)
 {
-    let data = $('.trumbowyg-editor').html();
+    let data = $('#case_narrative_editor').closest('.trumbowyg-box').find('.trumbowyg-editor').html();
 
     //g_textarea_oninput(p_object_path, p_metadata_path,p_dictionary_path, data);
     //return;
@@ -266,13 +266,11 @@ function textarea_control_strip_html_attributes(p_value)
 {
 
     let CommentRegex = /<!--\[[^>]+>/gi;
+    const NormalizeBr = /<br\s*\/>/gi;
 
     let Strip5PlusBr = /<br\><br\><br\><br\>+/gi;
 
-    let StripTrailingBR = /<br><br>(<br>|<br>.?)+/gi;
-
-    const Replace1 = /<br><\/p>/gi;
-    const Replace2 = /<br><\/span>/gi;
+    // Replace3/Replace4 clean up empty spans that paste operations leave behind
     const Replace3 = /<p><span [^>]+><\/span><\/p>/gi;
     const Replace4 = /<span [^>]+><\/span>/gi;
 
@@ -282,12 +280,10 @@ function textarea_control_strip_html_attributes(p_value)
 
     let node = document.createElement("body");
     node.innerHTML = p_value.replace(CommentRegex,"")
+        .replace(NormalizeBr,"<br>")
         .replace(crlf_regex," ")
         .replace(Strip5PlusBr,"<br><br>")
-        .replace(StripTrailingBR,"")
         .replace(PseudoTagRegex,"")
-        .replace(Replace1, "</p>")
-        .replace(Replace2, "</span>")
         .replace(Replace3,"")
         .replace(Replace4,"").trim();
 


### PR DESCRIPTION
Remove Replace1 (<br></p> -> </p>) and Replace2 (<br></span> -> </span>) from textarea_control_strip_html_attributes. These patterns were added in 73c95490a (2022-02-23) to clean up PDF paste artifacts but destroyed valid blank-line markup (<p><br></p>) in g_data on every tbwchange/tbwpaste event.

The PDF path (convert_html_to_pdf -> ConvertHTMLDOMWalker) never called this function, which masked the bug since 2022.

Also:
- Scope Trumbowyg HTML reads to #case_narrative_editor instead of global .trumbowyg-editor selector
- Normalize <br/> and <br /> to <br> before sanitization
- Remove StripTrailingBR which was deleting runs of 3+ consecutive <br> tags