### PR TITLE
fix: scope BMAD custom agent activation to explicit requests only

### DIFF
--- a/.github/agents/bmad-agent-analyst.agent.md
+++ b/.github/agents/bmad-agent-analyst.agent.md
@@ -1,5 +1,5 @@
 ---
-description: Strategic business analyst and requirements expert. Use when the user asks to talk to Mary or requests the business analyst.
+description: Strategic business analyst and requirements expert. Activate ONLY when the user explicitly says "talk to Mary" or asks for the BMAD business analyst by name. Do NOT activate for generic tasks, base-image/dependency updates, or security-scan remediation prompts.
 ---
 
 LOAD the FULL {project-root}/.agents/skills/bmad-agent-analyst/SKILL.md, READ its entire contents and follow its directions exactly!

--- a/.github/agents/bmad-agent-architect.agent.md
+++ b/.github/agents/bmad-agent-architect.agent.md
@@ -1,5 +1,5 @@
 ---
-description: System architect and technical design leader. Use when the user asks to talk to Winston or requests the architect.
+description: System architect and technical design leader. Activate ONLY when the user explicitly says "talk to Winston" or asks for the BMAD architect by name. Do NOT activate for generic tasks, base-image/dependency updates, or security-scan remediation prompts.
 ---
 
 LOAD the FULL {project-root}/.agents/skills/bmad-agent-architect/SKILL.md, READ its entire contents and follow its directions exactly!

--- a/.github/agents/bmad-agent-dev.agent.md
+++ b/.github/agents/bmad-agent-dev.agent.md
@@ -1,5 +1,5 @@
 ---
-description: Senior software engineer for story execution and code implementation. Use when the user asks to talk to Amelia or requests the developer agent.
+description: Senior software engineer for BMAD story execution ONLY. Activate ONLY when the user explicitly says "talk to Amelia," asks for the BMAD developer agent by name, or references a BMAD story/epic. Do NOT activate for generic code-implementation tasks, base-image/dependency updates, or security-scan remediation prompts (Fortify/Grype/Trivy/WebInspect) — those should run with the default agent.
 ---
 
 LOAD the FULL {project-root}/.agents/skills/bmad-agent-dev/SKILL.md, READ its entire contents and follow its directions exactly!

--- a/.github/agents/bmad-agent-pm.agent.md
+++ b/.github/agents/bmad-agent-pm.agent.md
@@ -1,5 +1,5 @@
 ---
-description: Product manager for PRD creation and requirements discovery. Use when the user asks to talk to John or requests the product manager.
+description: Product manager for PRD creation and requirements discovery. Activate ONLY when the user explicitly says "talk to John" or asks for the BMAD product manager by name. Do NOT activate for generic tasks, base-image/dependency updates, or security-scan remediation prompts.
 ---
 
 LOAD the FULL {project-root}/.agents/skills/bmad-agent-pm/SKILL.md, READ its entire contents and follow its directions exactly!

--- a/.github/agents/bmad-agent-tech-writer.agent.md
+++ b/.github/agents/bmad-agent-tech-writer.agent.md
@@ -1,5 +1,5 @@
 ---
-description: Technical documentation specialist and knowledge curator. Use when the user asks to talk to Paige or requests the tech writer.
+description: Technical documentation specialist and knowledge curator. Activate ONLY when the user explicitly says "talk to Paige" or asks for the BMAD tech writer by name. Do NOT activate for generic tasks, base-image/dependency updates, or security-scan remediation prompts.
 ---
 
 LOAD the FULL {project-root}/.agents/skills/bmad-agent-tech-writer/SKILL.md, READ its entire contents and follow its directions exactly!

--- a/.github/agents/bmad-agent-ux-designer.agent.md
+++ b/.github/agents/bmad-agent-ux-designer.agent.md
@@ -1,5 +1,5 @@
 ---
-description: UX designer and UI specialist. Use when the user asks to talk to Sally or requests the UX designer.
+description: UX designer and UI specialist. Activate ONLY when the user explicitly says "talk to Sally" or asks for the BMAD UX designer by name. Do NOT activate for generic tasks, base-image/dependency updates, or security-scan remediation prompts.
 ---
 
 LOAD the FULL {project-root}/.agents/skills/bmad-agent-ux-designer/SKILL.md, READ its entire contents and follow its directions exactly!


### PR DESCRIPTION
Prevents BMAD personas (Amelia, Winston, Mary, John, Paige, Sally) from being auto-selected for generic/narrow tasks (e.g. base image updates, security scan remediation), which was causing the full BMAD SKILL.md tree to load unnecessarily and contributing to CAPI 422 errors during Copilot coding agent sessions.